### PR TITLE
panicError handling for hooks

### DIFF
--- a/utils/cache_ctx.go
+++ b/utils/cache_ctx.go
@@ -18,11 +18,13 @@ func ApplyFuncIfNoError(ctx sdk.Context, f func(ctx sdk.Context) error) (err err
 	defer func() {
 		if recoveryError := recover(); recoveryError != nil {
 			PrintPanicRecoveryError(ctx, recoveryError)
+
 			err = errors.New("panic occurred during execution")
 		}
 	}()
 	// makes a new cache context, which all state changes get wrapped inside of.
 	cacheCtx, write := ctx.CacheContext()
+
 	err = f(cacheCtx)
 	if err != nil {
 		ctx.Logger().Error(err.Error())
@@ -32,6 +34,7 @@ func ApplyFuncIfNoError(ctx sdk.Context, f func(ctx sdk.Context) error) (err err
 		// Temporary, should be removed once: https://github.com/cosmos/cosmos-sdk/issues/12912
 		ctx.EventManager().EmitEvents(cacheCtx.EventManager().Events())
 	}
+
 	return err
 }
 
@@ -39,6 +42,7 @@ func ApplyFuncIfNoError(ctx sdk.Context, f func(ctx sdk.Context) error) (err err
 // If not emits them to stdout.
 func PrintPanicRecoveryError(ctx sdk.Context, recoveryError interface{}) {
 	errStackTrace := string(debug.Stack())
+
 	switch e := recoveryError.(type) {
 	case string:
 		ctx.Logger().Error("Recovering from (string) panic: " + e)
@@ -49,7 +53,9 @@ func PrintPanicRecoveryError(ctx sdk.Context, recoveryError interface{}) {
 	default:
 		ctx.Logger().Error("recovered (default) panic. Could not capture logs in ctx, see stdout")
 		fmt.Println("Recovering from panic ", recoveryError)
+
 		debug.PrintStack()
+
 		return
 	}
 	ctx.Logger().Error("stack trace: " + errStackTrace)

--- a/utils/cache_ctx.go
+++ b/utils/cache_ctx.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// ApplyFuncIfNoError This function lets you run the function f, but if theres an error or panic
+// drop the state machine change and log the error.
+// If there is no error, proceeds as normal (but with some slowdown due to SDK store weirdness)
+// Try to avoid usage of iterators in f.
+func ApplyFuncIfNoError(ctx sdk.Context, f func(ctx sdk.Context) error) (err error) {
+	// Add a panic safeguard
+	defer func() {
+		if recoveryError := recover(); recoveryError != nil {
+			PrintPanicRecoveryError(ctx, recoveryError)
+			err = errors.New("panic occurred during execution")
+		}
+	}()
+	// makes a new cache context, which all state changes get wrapped inside of.
+	cacheCtx, write := ctx.CacheContext()
+	err = f(cacheCtx)
+	if err != nil {
+		ctx.Logger().Error(err.Error())
+	} else {
+		// no error, write the output of f
+		write()
+		// Temporary, should be removed once: https://github.com/cosmos/cosmos-sdk/issues/12912
+		ctx.EventManager().EmitEvents(cacheCtx.EventManager().Events())
+	}
+	return err
+}
+
+// PrintPanicRecoveryError error logs the recoveryError, along with the stacktrace, if it can be parsed.
+// If not emits them to stdout.
+func PrintPanicRecoveryError(ctx sdk.Context, recoveryError interface{}) {
+	errStackTrace := string(debug.Stack())
+	switch e := recoveryError.(type) {
+	case string:
+		ctx.Logger().Error("Recovering from (string) panic: " + e)
+	case runtime.Error:
+		ctx.Logger().Error("recovered (runtime.Error) panic: " + e.Error())
+	case error:
+		ctx.Logger().Error("recovered (error) panic: " + e.Error())
+	default:
+		ctx.Logger().Error("recovered (default) panic. Could not capture logs in ctx, see stdout")
+		fmt.Println("Recovering from panic ", recoveryError)
+		debug.PrintStack()
+		return
+	}
+	ctx.Logger().Error("stack trace: " + errStackTrace)
+}

--- a/utils/epoch.go
+++ b/utils/epoch.go
@@ -1,34 +1,10 @@
 package utils
 
 import (
-	"fmt"
-	"runtime"
-	"runtime/debug"
 	"sort"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"golang.org/x/exp/constraints"
 )
-
-func PrintPanicRecoveryError(ctx sdk.Context, recoveryError interface{}) {
-	errStackTrace := string(debug.Stack())
-
-	switch e := recoveryError.(type) {
-	case string:
-		ctx.Logger().Error("Recovering from (string) panic: " + e)
-	case runtime.Error:
-		ctx.Logger().Error("recovered (runtime.Error) panic: " + e.Error())
-	case error:
-		ctx.Logger().Error("recovered (error) panic: " + e.Error())
-	default:
-		ctx.Logger().Error("recovered (default) panic. Could not capture logs in ctx, see stdout")
-		fmt.Println("Recovering from panic ", recoveryError)
-		debug.PrintStack()
-
-		return
-	}
-	ctx.Logger().Error("stack trace: " + errStackTrace)
-}
 
 func SortSlice[T constraints.Ordered](s []T) {
 	sort.Slice(s, func(i, j int) bool {

--- a/x/ibchooker/keeper/hooks.go
+++ b/x/ibchooker/keeper/hooks.go
@@ -4,26 +4,22 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	channelTypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	"github.com/cosmos/ibc-go/v3/modules/core/exported"
-
-	"github.com/persistenceOne/persistence-sdk/x/ibchooker/types"
 )
-
-var _ types.IBCHandshakeHooks = Keeper{}
 
 func (k Keeper) OnRecvPacket(ctx sdk.Context, packet channelTypes.Packet, relayer sdk.AccAddress, transferAck exported.Acknowledgement) {
 	if k.hooks != nil {
-		k.hooks.OnRecvPacket(ctx, packet, relayer, transferAck)
+		_ = k.hooks.OnRecvPacket(ctx, packet, relayer, transferAck)
 	}
 }
 
 func (k Keeper) OnAcknowledgementPacket(ctx sdk.Context, packet channelTypes.Packet, acknowledgement []byte, relayer sdk.AccAddress, transferAckErr error) {
 	if k.hooks != nil {
-		k.hooks.OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer, transferAckErr)
+		_ = k.hooks.OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer, transferAckErr)
 	}
 }
 
 func (k Keeper) OnTimeoutPacket(ctx sdk.Context, packet channelTypes.Packet, relayer sdk.AccAddress, transferTimeoutErr error) {
 	if k.hooks != nil {
-		k.hooks.OnTimeoutPacket(ctx, packet, relayer, transferTimeoutErr)
+		_ = k.hooks.OnTimeoutPacket(ctx, packet, relayer, transferTimeoutErr)
 	}
 }

--- a/x/ibchooker/types/exported_keepers.go
+++ b/x/ibchooker/types/exported_keepers.go
@@ -8,7 +8,7 @@ import (
 
 type IBCHandshakeHooks interface {
 	// Do we care about `relayer sdk.AccAddress` argument here?
-	OnRecvPacket(ctx sdk.Context, packet types.Packet, relayer sdk.AccAddress, transferAck exported.Acknowledgement)
-	OnAcknowledgementPacket(ctx sdk.Context, packet types.Packet, acknowledgement []byte, relayer sdk.AccAddress, transferAckErr error)
-	OnTimeoutPacket(ctx sdk.Context, packet types.Packet, relayer sdk.AccAddress, transferTimeoutErr error)
+	OnRecvPacket(ctx sdk.Context, packet types.Packet, relayer sdk.AccAddress, transferAck exported.Acknowledgement) error
+	OnAcknowledgementPacket(ctx sdk.Context, packet types.Packet, acknowledgement []byte, relayer sdk.AccAddress, transferAckErr error) error
+	OnTimeoutPacket(ctx sdk.Context, packet types.Packet, relayer sdk.AccAddress, transferTimeoutErr error) error
 }

--- a/x/ibchooker/types/hooks.go
+++ b/x/ibchooker/types/hooks.go
@@ -4,6 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	"github.com/cosmos/ibc-go/v3/modules/core/exported"
+
 	"github.com/persistenceOne/persistence-sdk/utils"
 )
 
@@ -24,6 +25,7 @@ func (h MultiIBCHandshakeHooks) OnRecvPacket(ctx sdk.Context, packet types.Packe
 		err := utils.ApplyFuncIfNoError(ctx, wrappedHookFn)
 		ctx.Logger().Error("Error occurred in calling OnRecvPacket hooks, ", "err: ", err, "module:", ModuleName, "index:", i)
 	}
+
 	return nil
 }
 
@@ -35,6 +37,7 @@ func (h MultiIBCHandshakeHooks) OnAcknowledgementPacket(ctx sdk.Context, packet 
 		err := utils.ApplyFuncIfNoError(ctx, wrappedHookFn)
 		ctx.Logger().Error("Error occurred in calling OnAcknowledgementPacket hooks, ", "err: ", err, "module:", ModuleName, "index:", i)
 	}
+
 	return nil
 }
 
@@ -46,5 +49,6 @@ func (h MultiIBCHandshakeHooks) OnTimeoutPacket(ctx sdk.Context, packet types.Pa
 		err := utils.ApplyFuncIfNoError(ctx, wrappedHookFn)
 		ctx.Logger().Error("Error occurred in calling OnTimeoutPacket hooks, ", "err: ", err, "module:", ModuleName, "index:", i)
 	}
+
 	return nil
 }

--- a/x/ibchooker/types/hooks.go
+++ b/x/ibchooker/types/hooks.go
@@ -4,6 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	"github.com/cosmos/ibc-go/v3/modules/core/exported"
+	"github.com/persistenceOne/persistence-sdk/utils"
 )
 
 var _ IBCHandshakeHooks = MultiIBCHandshakeHooks{}
@@ -17,18 +18,75 @@ func NewMultiStakingHooks(hooks ...IBCHandshakeHooks) MultiIBCHandshakeHooks {
 
 func (h MultiIBCHandshakeHooks) OnRecvPacket(ctx sdk.Context, packet types.Packet, relayer sdk.AccAddress, transferAck exported.Acknowledgement) {
 	for i := range h {
-		h[i].OnRecvPacket(ctx, packet, relayer, transferAck)
+		panicCatchingOnRecvPacketFnHook(ctx, h[i].OnRecvPacket, packet, relayer, transferAck)
 	}
 }
 
 func (h MultiIBCHandshakeHooks) OnAcknowledgementPacket(ctx sdk.Context, packet types.Packet, acknowledgement []byte, relayer sdk.AccAddress, transferAckErr error) {
 	for i := range h {
-		h[i].OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer, transferAckErr)
+		panicCatchingOnAcknowledgementPacketFnHook(ctx, h[i].OnAcknowledgementPacket, packet, acknowledgement, relayer, transferAckErr)
 	}
 }
 
 func (h MultiIBCHandshakeHooks) OnTimeoutPacket(ctx sdk.Context, packet types.Packet, relayer sdk.AccAddress, transferTimeoutErr error) {
 	for i := range h {
-		h[i].OnTimeoutPacket(ctx, packet, relayer, transferTimeoutErr)
+		panicCatchingOnTimeoutPacketFnHook(ctx, h[i].OnTimeoutPacket, packet, relayer, transferTimeoutErr)
 	}
+}
+
+// Panic catching Fn implementations
+// We want to be using cacheContext in case of failure not to write entire code block
+func panicCatchingOnRecvPacketFnHook(
+	ctx sdk.Context,
+	onRecvPacketFn func(ctx sdk.Context, packet types.Packet, relayer sdk.AccAddress, transferAck exported.Acknowledgement),
+	packet types.Packet,
+	relayer sdk.AccAddress,
+	transferAck exported.Acknowledgement,
+) {
+	defer func() {
+		if recovErr := recover(); recovErr != nil {
+			utils.PrintPanicRecoveryError(ctx, recovErr)
+		}
+	}()
+
+	cacheCtx, write := ctx.CacheContext()
+	onRecvPacketFn(cacheCtx, packet, relayer, transferAck)
+	write()
+}
+
+func panicCatchingOnAcknowledgementPacketFnHook(
+	ctx sdk.Context,
+	onAcknowledgementPacketFn func(ctx sdk.Context, packet types.Packet, acknowledgement []byte, relayer sdk.AccAddress, transferAckErr error),
+	packet types.Packet,
+	acknowledgement []byte,
+	relayer sdk.AccAddress,
+	transferAckErr error,
+) {
+	defer func() {
+		if recovErr := recover(); recovErr != nil {
+			utils.PrintPanicRecoveryError(ctx, recovErr)
+		}
+	}()
+
+	cacheCtx, write := ctx.CacheContext()
+	onAcknowledgementPacketFn(cacheCtx, packet, acknowledgement, relayer, transferAckErr)
+	write()
+}
+
+func panicCatchingOnTimeoutPacketFnHook(
+	ctx sdk.Context,
+	onTimeoutPacketFn func(ctx sdk.Context, packet types.Packet, relayer sdk.AccAddress, transferTimeoutErr error),
+	packet types.Packet,
+	relayer sdk.AccAddress,
+	transferTimeoutErr error,
+) {
+	defer func() {
+		if recovErr := recover(); recovErr != nil {
+			utils.PrintPanicRecoveryError(ctx, recovErr)
+		}
+	}()
+
+	cacheCtx, write := ctx.CacheContext()
+	onTimeoutPacketFn(cacheCtx, packet, relayer, transferTimeoutErr)
+	write()
 }

--- a/x/ibchooker/types/hooks.go
+++ b/x/ibchooker/types/hooks.go
@@ -32,7 +32,6 @@ func (h MultiIBCHandshakeHooks) OnAcknowledgementPacket(ctx sdk.Context, packet 
 		wrappedHookFn := func(ctx sdk.Context) error {
 			return h[i].OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer, transferAckErr)
 		}
-		// error is already logged
 		err := utils.ApplyFuncIfNoError(ctx, wrappedHookFn)
 		ctx.Logger().Error("Error occurred in calling OnAcknowledgementPacket hooks, ", "err: ", err, "module:", ModuleName, "index:", i)
 	}
@@ -44,7 +43,6 @@ func (h MultiIBCHandshakeHooks) OnTimeoutPacket(ctx sdk.Context, packet types.Pa
 		wrappedHookFn := func(ctx sdk.Context) error {
 			return h[i].OnTimeoutPacket(ctx, packet, relayer, transferTimeoutErr)
 		}
-		// error is already logged
 		err := utils.ApplyFuncIfNoError(ctx, wrappedHookFn)
 		ctx.Logger().Error("Error occurred in calling OnTimeoutPacket hooks, ", "err: ", err, "module:", ModuleName, "index:", i)
 	}

--- a/x/ibchooker/types/hooks.go
+++ b/x/ibchooker/types/hooks.go
@@ -20,6 +20,7 @@ func NewMultiStakingHooks(hooks ...IBCHandshakeHooks) MultiIBCHandshakeHooks {
 func (h MultiIBCHandshakeHooks) OnRecvPacket(ctx sdk.Context, packet types.Packet, relayer sdk.AccAddress, transferAck exported.Acknowledgement) error {
 	for i := range h {
 		wrappedHookFn := func(ctx sdk.Context) error {
+			//nolint:scopelint
 			return h[i].OnRecvPacket(ctx, packet, relayer, transferAck)
 		}
 		err := utils.ApplyFuncIfNoError(ctx, wrappedHookFn)
@@ -32,6 +33,7 @@ func (h MultiIBCHandshakeHooks) OnRecvPacket(ctx sdk.Context, packet types.Packe
 func (h MultiIBCHandshakeHooks) OnAcknowledgementPacket(ctx sdk.Context, packet types.Packet, acknowledgement []byte, relayer sdk.AccAddress, transferAckErr error) error {
 	for i := range h {
 		wrappedHookFn := func(ctx sdk.Context) error {
+			//nolint:scopelint
 			return h[i].OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer, transferAckErr)
 		}
 		err := utils.ApplyFuncIfNoError(ctx, wrappedHookFn)
@@ -44,6 +46,7 @@ func (h MultiIBCHandshakeHooks) OnAcknowledgementPacket(ctx sdk.Context, packet 
 func (h MultiIBCHandshakeHooks) OnTimeoutPacket(ctx sdk.Context, packet types.Packet, relayer sdk.AccAddress, transferTimeoutErr error) error {
 	for i := range h {
 		wrappedHookFn := func(ctx sdk.Context) error {
+			//nolint:scopelint
 			return h[i].OnTimeoutPacket(ctx, packet, relayer, transferTimeoutErr)
 		}
 		err := utils.ApplyFuncIfNoError(ctx, wrappedHookFn)


### PR DESCRIPTION
## 1. Overview

Handles panics in hooks functions

## 2. Implementation details

- uses panic recovery function used by [osmosis epochs hooks](https://github.com/osmosis-labs/osmosis/blob/main/x/epochs/types/hooks.go#L39)
- https://github.com/osmosis-labs/osmosis/pull/2515
- https://github.com/osmosis-labs/osmosis/issues/2520

## 3. How to test/use

- No tests, but code blocks panicing will not change state

## 4. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

## 5. Limitations (optional)

- We still do not handle error

## 6. Future Work (optional)

- Handle checks by changing hooks to return errors