### PR TITLE
add cached events to main event handler

### DIFF
--- a/x/epochs/types/hooks.go
+++ b/x/epochs/types/hooks.go
@@ -51,4 +51,5 @@ func panicCatchingEpochHook(
 	cacheCtx, write := ctx.CacheContext()
 	hookFn(cacheCtx, epochIdentifier, epochNumber)
 	write()
+	ctx.EventManager().EmitEvents(cacheCtx.EventManager().Events())
 }


### PR DESCRIPTION
## 1. Overview

- emit events from cached ctx from osmosis-epoch

## 2. Implementation details

- osmosis has added panic handling for modules that implement the begin blocker hooks, it uses cachectx which is dumped after writing the state.
- the implementation appends events from cached ctx and adds it to the main ctx.

## 3. How to test/use

- relayers are able to catch events if we execute ibc transfer in begin blocker

## 4. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

