### PR TITLE
Puneet/epochfixs

### DIFF
--- a/x/epochs/types/hooks.go
+++ b/x/epochs/types/hooks.go
@@ -51,4 +51,5 @@ func panicCatchingEpochHook(
 	cacheCtx, write := ctx.CacheContext()
 	hookFn(cacheCtx, epochIdentifier, epochNumber)
 	write()
+	ctx.EventManager().EmitEvents(cacheCtx.EventManager().Events())
 }

--- a/x/epochs/types/hooks_test.go
+++ b/x/epochs/types/hooks_test.go
@@ -57,6 +57,7 @@ func (hook *dummyEpochHook) AfterEpochEnd(ctx sdk.Context, epochIdentifier strin
 	}
 
 	hook.successCounter++
+
 	ctx.EventManager().EmitEvent(dummyAfterEpochEndEvent(epochIdentifier, epochNumber))
 }
 
@@ -66,6 +67,7 @@ func (hook *dummyEpochHook) BeforeEpochStart(ctx sdk.Context, epochIdentifier st
 	}
 
 	hook.successCounter++
+
 	ctx.EventManager().EmitEvent(dummyBeforeEpochStartEvent(epochIdentifier, epochNumber))
 }
 

--- a/x/epochs/types/hooks_test.go
+++ b/x/epochs/types/hooks_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"strconv"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -26,6 +27,22 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.queryClient = types.NewQueryClient(suite.QueryHelper)
 }
 
+func dummyAfterEpochEndEvent(epochIdentifier string, epochNumber int64) sdk.Event {
+	return sdk.NewEvent(
+		"afterEpochEnd",
+		sdk.NewAttribute("epochIdentifier", epochIdentifier),
+		sdk.NewAttribute("epochNumber", strconv.FormatInt(epochNumber, 10)),
+	)
+}
+
+func dummyBeforeEpochStartEvent(epochIdentifier string, epochNumber int64) sdk.Event {
+	return sdk.NewEvent(
+		"beforeEpochStart",
+		sdk.NewAttribute("epochIdentifier", epochIdentifier),
+		sdk.NewAttribute("epochNumber", strconv.FormatInt(epochNumber, 10)),
+	)
+}
+
 // dummyEpochHook is a struct satisfying the epoch hook interface,
 // that maintains a counter for how many times its been successfully called,
 // and a boolean for whether it should panic during its execution.
@@ -38,14 +55,18 @@ func (hook *dummyEpochHook) AfterEpochEnd(ctx sdk.Context, epochIdentifier strin
 	if hook.shouldPanic {
 		panic("dummyEpochHook is panicking")
 	}
+
 	hook.successCounter++
+	ctx.EventManager().EmitEvent(dummyAfterEpochEndEvent(epochIdentifier, epochNumber))
 }
 
 func (hook *dummyEpochHook) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
 	if hook.shouldPanic {
 		panic("dummyEpochHook is panicking")
 	}
+
 	hook.successCounter++
+	ctx.EventManager().EmitEvent(dummyBeforeEpochStartEvent(epochIdentifier, epochNumber))
 }
 
 func (hook *dummyEpochHook) Clone() *dummyEpochHook {
@@ -55,7 +76,7 @@ func (hook *dummyEpochHook) Clone() *dummyEpochHook {
 
 var _ types.EpochHooks = &dummyEpochHook{}
 
-func (suite *KeeperTestSuite) TestHooksPanicRecovery() {
+func (suite *KeeperTestSuite) TestHooksPanicRecoveryAndEvents() {
 	panicHook := dummyEpochHook{shouldPanic: true}
 	noPanicHook := dummyEpochHook{shouldPanic: false}
 	simpleHooks := []dummyEpochHook{panicHook, noPanicHook}
@@ -84,8 +105,13 @@ func (suite *KeeperTestSuite) TestHooksPanicRecovery() {
 				//nolint:scopelint,testfile
 				if epochActionSelector == 0 {
 					hooks.BeforeEpochStart(suite.Ctx, "id", 0)
+					suite.Require().Equal(suite.Ctx.EventManager().Events(), sdk.Events{dummyBeforeEpochStartEvent("id", 0)},
+						"test case index %d, before epoch event check", tcIndex)
 				} else if epochActionSelector == 1 {
 					hooks.AfterEpochEnd(suite.Ctx, "id", 0)
+					suite.Require().Equal(suite.Ctx.EventManager().Events(), sdk.Events{dummyAfterEpochEndEvent("id", 0)},
+						"test case index %d, after epoch event check", tcIndex)
+
 				}
 			})
 


### PR DESCRIPTION
## 1. Overview
https://github.com/osmosis-labs/osmosis/pull/2515

- emit events from cached ctx from osmosis-epoch

## 2. Implementation details

- osmosis has added panic handling for modules that implement the begin blocker hooks, it uses cachectx which is dumped after writing the state.
- the implementation appends events from cached ctx and adds it to the main ctx.

## 3. How to test/use

- relayers are able to catch events if we execute ibc transfer in begin blocker

## 4. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

