### PR TITLE
Filter out the votes below the vote threshold

### DIFF
--- a/x/oracle/keeper/ballot.go
+++ b/x/oracle/keeper/ballot.go
@@ -24,11 +24,9 @@ func (k Keeper) OrganizeBallotByDenom(
 			power := claim.Power
 
 			for _, tuple := range vote.ExchangeRateTuples {
-				tmpPower := power
-
 				votes[tuple.Denom] = append(
 					votes[tuple.Denom],
-					types.NewVoteForTally(tuple.ExchangeRate, tuple.Denom, voterAddr, tmpPower),
+					types.NewVoteForTally(tuple.ExchangeRate, tuple.Denom, voterAddr, power),
 				)
 			}
 		}
@@ -47,13 +45,14 @@ func (k Keeper) OrganizeBallotByDenom(
 	return types.BallotMapToSlice(votes)
 }
 
-// ClearBallots clears all tallied prevotes and votes from the store.
-func (k Keeper) ClearBallots(ctx sdk.Context, votePeriod uint64) {
+// ClearVotes clears all tallied prevotes and votes from the store.
+func (k Keeper) ClearVotes(ctx sdk.Context, votePeriod uint64) {
+	currentHeight := uint64(ctx.BlockHeight())
 	// clear all aggregate prevotes
 	k.IterateAggregateExchangeRatePrevotes(
 		ctx,
 		func(voterAddr sdk.ValAddress, aggPrevote types.AggregateExchangeRatePrevote) bool {
-			if ctx.BlockHeight() > int64(aggPrevote.SubmitBlock+votePeriod) {
+			if currentHeight > aggPrevote.SubmitBlock+votePeriod {
 				k.DeleteAggregateExchangeRatePrevote(ctx, voterAddr)
 			}
 

--- a/x/oracle/keeper/ballot_test.go
+++ b/x/oracle/keeper/ballot_test.go
@@ -44,6 +44,7 @@ func (s *KeeperTestSuite) TestBallot_OrganizeBallotByDenom() {
 
 func (s *KeeperTestSuite) TestBallot_ClearBallots() {
 	addr, valAddr := s.accAddresses[0], s.valAddresses[0]
+
 	prevote := types.AggregateExchangeRatePrevote{
 		Hash:        "hash",
 		Voter:       addr.String(),
@@ -68,7 +69,7 @@ func (s *KeeperTestSuite) TestBallot_ClearBallots() {
 	s.Require().NoError(err)
 	s.Require().Equal(voteRes, vote)
 
-	s.app.OracleKeeper.ClearBallots(s.ctx, 0)
+	s.app.OracleKeeper.ClearVotes(s.ctx, 0)
 	_, err = s.app.OracleKeeper.GetAggregateExchangeRatePrevote(s.ctx, valAddr)
 	s.Require().Error(err)
 	_, err = s.app.OracleKeeper.GetAggregateExchangeRateVote(s.ctx, valAddr)

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -109,7 +109,9 @@ func (k Keeper) SetExchangeRateWithEvent(ctx sdk.Context, denom string, exchange
 func (k Keeper) ClearExchangeRates(ctx sdk.Context) {
 	store := ctx.KVStore(k.storeKey)
 	iter := sdk.KVStorePrefixIterator(store, types.KeyPrefixExchangeRate)
+
 	defer iter.Close()
+
 	for ; iter.Valid(); iter.Next() {
 		store.Delete(iter.Key())
 	}

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -105,12 +105,14 @@ func (k Keeper) SetExchangeRateWithEvent(ctx sdk.Context, denom string, exchange
 	)
 }
 
-// DeleteExchangeRate deletes the consensus exchange rate of XPRT denominated in
-// the denom asset from the store.
-func (k Keeper) DeleteExchangeRate(ctx sdk.Context, denom string) {
+// ClearExchangeRates clears all exchange rates from the store.
+func (k Keeper) ClearExchangeRates(ctx sdk.Context) {
 	store := ctx.KVStore(k.storeKey)
-	denom = strings.ToUpper(denom)
-	store.Delete(types.GetExchangeRateKey(denom))
+	iter := sdk.KVStorePrefixIterator(store, types.KeyPrefixExchangeRate)
+	defer iter.Close()
+	for ; iter.Valid(); iter.Next() {
+		store.Delete(iter.Key())
+	}
 }
 
 // IterateExchangeRates iterates over XPRT rates in the store.

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -213,11 +213,11 @@ func (s *KeeperTestSuite) TestGetExchangeRate_Valid() {
 	s.Require().Equal(rate, sdk.OneDec())
 }
 
-func (s *KeeperTestSuite) TestDeleteExchangeRate() {
+func (s *KeeperTestSuite) TestClearExchangeRate() {
 	app, ctx := s.app, s.ctx
 
 	app.OracleKeeper.SetExchangeRate(ctx, types.PersistenceDenom, sdk.OneDec())
-	app.OracleKeeper.DeleteExchangeRate(ctx, types.PersistenceDenom)
+	app.OracleKeeper.ClearExchangeRates(ctx)
 	_, err := app.OracleKeeper.GetExchangeRate(ctx, types.PersistenceDenom)
 	s.Require().Error(err)
 }

--- a/x/oracle/keeper/params.go
+++ b/x/oracle/keeper/params.go
@@ -12,10 +12,34 @@ func (k Keeper) VotePeriod(ctx sdk.Context) (res uint64) {
 	return
 }
 
+// SetVotePeriod sets the number of blocks during which voting takes place.
+func (k Keeper) SetVotePeriod(ctx sdk.Context, votePeriod uint64) {
+	k.paramSpace.Set(ctx, types.KeyVotePeriod, &votePeriod)
+}
+
 // VoteThreshold returns the minimum percentage of votes that must be received
 // for a ballot to pass.
 func (k Keeper) VoteThreshold(ctx sdk.Context) (res sdk.Dec) {
 	k.paramSpace.Get(ctx, types.KeyVoteThreshold, &res)
+	return
+}
+
+// SetVoteTHreshold sets the minimum percentage of votes that must be received
+// for a ballot to pass.
+func (k Keeper) SetVoteThreshold(ctx sdk.Context, voteThreshold sdk.Dec) error {
+	if err := types.ValidateVoteThreshold(voteThreshold); err != nil {
+		return err
+	}
+
+	k.paramSpace.Set(ctx, types.KeyVoteThreshold, &voteThreshold)
+
+	return nil
+}
+
+// RewardBand returns the ratio of allowable exchange rate error that a validator
+// can be rewarded.
+func (k Keeper) RewardBand(ctx sdk.Context) (res sdk.Dec) {
+	k.paramSpace.Get(ctx, types.KeyRewardBand, &res)
 	return
 }
 
@@ -24,6 +48,18 @@ func (k Keeper) VoteThreshold(ctx sdk.Context) (res sdk.Dec) {
 func (k Keeper) RewardDistributionWindow(ctx sdk.Context) (res uint64) {
 	k.paramSpace.Get(ctx, types.KeyRewardDistributionWindow, &res)
 	return
+}
+
+// AcceptList returns the denom list that can be activated
+func (k Keeper) AcceptList(ctx sdk.Context) (res types.DenomList) {
+	k.paramSpace.Get(ctx, types.KeyAcceptList, &res)
+	return
+}
+
+// SetAcceptList updates the accepted list of assets supported by the x/oracle
+// module.
+func (k Keeper) SetAcceptList(ctx sdk.Context, acceptList types.DenomList) {
+	k.paramSpace.Set(ctx, types.KeyAcceptList, acceptList)
 }
 
 // SlashFraction returns oracle voting penalty rate

--- a/x/oracle/keeper/params.go
+++ b/x/oracle/keeper/params.go
@@ -6,76 +6,40 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// VotePeriod returns the number of blocks during which voting takes place.
-func (k Keeper) VotePeriod(ctx sdk.Context) (res uint64) {
+// GetVotePeriod returns the number of blocks during which voting takes place.
+func (k Keeper) GetVotePeriod(ctx sdk.Context) (res uint64) {
 	k.paramSpace.Get(ctx, types.KeyVotePeriod, &res)
 	return
 }
 
-// SetVotePeriod sets the number of blocks during which voting takes place.
-func (k Keeper) SetVotePeriod(ctx sdk.Context, votePeriod uint64) {
-	k.paramSpace.Set(ctx, types.KeyVotePeriod, &votePeriod)
-}
-
-// VoteThreshold returns the minimum percentage of votes that must be received
+// GetVoteThreshold returns the minimum percentage of votes that must be received
 // for a ballot to pass.
-func (k Keeper) VoteThreshold(ctx sdk.Context) (res sdk.Dec) {
+func (k Keeper) GetVoteThreshold(ctx sdk.Context) (res sdk.Dec) {
 	k.paramSpace.Get(ctx, types.KeyVoteThreshold, &res)
 	return
 }
 
-// SetVoteTHreshold sets the minimum percentage of votes that must be received
-// for a ballot to pass.
-func (k Keeper) SetVoteThreshold(ctx sdk.Context, voteThreshold sdk.Dec) error {
-	if err := types.ValidateVoteThreshold(voteThreshold); err != nil {
-		return err
-	}
-
-	k.paramSpace.Set(ctx, types.KeyVoteThreshold, &voteThreshold)
-
-	return nil
-}
-
-// RewardBand returns the ratio of allowable exchange rate error that a validator
-// can be rewarded.
-func (k Keeper) RewardBand(ctx sdk.Context) (res sdk.Dec) {
-	k.paramSpace.Get(ctx, types.KeyRewardBand, &res)
-	return
-}
-
-// RewardDistributionWindow returns the number of vote periods during which
+// GetRewardDistributionWindow returns the number of vote periods during which
 // seigniorage reward comes in and then is distributed.
-func (k Keeper) RewardDistributionWindow(ctx sdk.Context) (res uint64) {
+func (k Keeper) GetRewardDistributionWindow(ctx sdk.Context) (res uint64) {
 	k.paramSpace.Get(ctx, types.KeyRewardDistributionWindow, &res)
 	return
 }
 
-// AcceptList returns the denom list that can be activated
-func (k Keeper) AcceptList(ctx sdk.Context) (res types.DenomList) {
-	k.paramSpace.Get(ctx, types.KeyAcceptList, &res)
-	return
-}
-
-// SetAcceptList updates the accepted list of assets supported by the x/oracle
-// module.
-func (k Keeper) SetAcceptList(ctx sdk.Context, acceptList types.DenomList) {
-	k.paramSpace.Set(ctx, types.KeyAcceptList, acceptList)
-}
-
-// SlashFraction returns oracle voting penalty rate
-func (k Keeper) SlashFraction(ctx sdk.Context) (res sdk.Dec) {
+// GetSlashFraction returns oracle voting penalty rate
+func (k Keeper) GetSlashFraction(ctx sdk.Context) (res sdk.Dec) {
 	k.paramSpace.Get(ctx, types.KeySlashFraction, &res)
 	return
 }
 
-// SlashWindow returns # of vote period for oracle slashing
-func (k Keeper) SlashWindow(ctx sdk.Context) (res uint64) {
+// GetSlashWindow returns # of vote period for oracle slashing
+func (k Keeper) GetSlashWindow(ctx sdk.Context) (res uint64) {
 	k.paramSpace.Get(ctx, types.KeySlashWindow, &res)
 	return
 }
 
-// MinValidPerWindow returns oracle slashing threshold
-func (k Keeper) MinValidPerWindow(ctx sdk.Context) (res sdk.Dec) {
+// GetMinValidPerWindow returns oracle slashing threshold
+func (k Keeper) GetMinValidPerWindow(ctx sdk.Context) (res sdk.Dec) {
 	k.paramSpace.Get(ctx, types.KeyMinValidPerWindow, &res)
 	return
 }
@@ -83,7 +47,7 @@ func (k Keeper) MinValidPerWindow(ctx sdk.Context) (res sdk.Dec) {
 // GetParams returns the total set of oracle parameters.
 func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
 	k.paramSpace.GetParamSet(ctx, &params)
-	return params
+	return
 }
 
 // SetParams sets the total set of oracle parameters.

--- a/x/oracle/keeper/params_test.go
+++ b/x/oracle/keeper/params_test.go
@@ -8,7 +8,7 @@ import (
 func (s *KeeperTestSuite) TestVoteThreshold() {
 	app, ctx := s.app, s.ctx
 
-	voteDec := app.OracleKeeper.VoteThreshold(ctx)
+	voteDec := app.OracleKeeper.GetVoteThreshold(ctx)
 	s.Require().Equal(sdk.MustNewDecFromStr("0.5"), voteDec)
 
 	newVoteTreshold := sdk.MustNewDecFromStr("0.6")
@@ -16,6 +16,6 @@ func (s *KeeperTestSuite) TestVoteThreshold() {
 	defaultParams.VoteThreshold = newVoteTreshold
 	app.OracleKeeper.SetParams(ctx, defaultParams)
 
-	voteThresholdDec := app.OracleKeeper.VoteThreshold(ctx)
+	voteThresholdDec := app.OracleKeeper.GetVoteThreshold(ctx)
 	s.Require().Equal(newVoteTreshold, voteThresholdDec)
 }

--- a/x/oracle/keeper/reward_test.go
+++ b/x/oracle/keeper/reward_test.go
@@ -32,11 +32,11 @@ func (s *KeeperTestSuite) TestRewardBallotWinners() {
 		voteTargets[i] = v.SymbolDenom
 	}
 
-	votePeriodsPerWindow := sdk.NewDec((int64)(s.app.OracleKeeper.RewardDistributionWindow(s.ctx))).
-		QuoInt64((int64)(s.app.OracleKeeper.VotePeriod(s.ctx))).
+	votePeriodsPerWindow := sdk.NewDec((int64)(s.app.OracleKeeper.GetRewardDistributionWindow(s.ctx))).
+		QuoInt64((int64)(s.app.OracleKeeper.GetVotePeriod(s.ctx))).
 		TruncateInt64()
 
-	s.app.OracleKeeper.RewardBallotWinners(s.ctx, (int64)(s.app.OracleKeeper.VotePeriod(s.ctx)), (int64)(s.app.OracleKeeper.RewardDistributionWindow(s.ctx)), voteTargets, claims)
+	s.app.OracleKeeper.RewardBallotWinners(s.ctx, (int64)(s.app.OracleKeeper.GetVotePeriod(s.ctx)), (int64)(s.app.OracleKeeper.GetRewardDistributionWindow(s.ctx)), voteTargets, claims)
 
 	outstandingRewardsDec := s.app.DistrKeeper.GetValidatorOutstandingRewardsCoins(s.ctx, valAddr)
 	outstandingRewards, _ := outstandingRewardsDec.TruncateDecimal()

--- a/x/oracle/keeper/slash.go
+++ b/x/oracle/keeper/slash.go
@@ -16,14 +16,14 @@ func (k Keeper) SlashAndResetMissCounters(ctx sdk.Context) {
 	distributionHeight := height - sdk.ValidatorUpdateDelay - 1
 
 	var (
-		slashWindow          = int64(k.SlashWindow(ctx))
-		votePeriod           = int64(k.VotePeriod(ctx))
+		slashWindow          = int64(k.GetSlashWindow(ctx))
+		votePeriod           = int64(k.GetVotePeriod(ctx))
 		votePeriodsPerWindow = sdk.NewDec(slashWindow).QuoInt64(votePeriod).TruncateInt64()
 	)
 
 	var (
-		minValidPerWindow = k.MinValidPerWindow(ctx)
-		slashFraction     = k.SlashFraction(ctx)
+		minValidPerWindow = k.GetMinValidPerWindow(ctx)
+		slashFraction     = k.GetSlashFraction(ctx)
 		powerReduction    = k.StakingKeeper.PowerReduction(ctx)
 	)
 

--- a/x/oracle/keeper/slash_test.go
+++ b/x/oracle/keeper/slash_test.go
@@ -44,9 +44,11 @@ func (s *KeeperTestSuite) TestSlashAndResetMissCounters() {
 	// Case 2, slash
 	s.app.OracleKeeper.SetMissCounter(s.ctx, valAddr, missCounterSlash)
 	s.app.OracleKeeper.SlashAndResetMissCounters(s.ctx)
+
 	validator, _ = s.app.StakingKeeper.GetValidator(s.ctx, valAddr)
 	s.Require().Equal(amt.Sub(params.SlashFraction.MulInt(amt).TruncateInt()), validator.GetBondedTokens())
 	s.Require().True(validator.Jailed)
+
 	missCounter := app.OracleKeeper.GetMissCounter(ctx, valAddr)
 	s.Require().Zero(missCounter)
 

--- a/x/oracle/keeper/tally.go
+++ b/x/oracle/keeper/tally.go
@@ -26,8 +26,8 @@ func (k Keeper) BuildClaimsMapAndTally(ctx sdk.Context, params types.Params) err
 
 	var (
 		// voteTargets defines the symbol (ticker) denoms that we require votes on
-		voteTargets      = make([]string, len(params.AcceptList))
-		voteTargetDenoms = make([]string, len(params.AcceptList))
+		voteTargets      = make([]string, 0, len(params.AcceptList))
+		voteTargetDenoms = make([]string, 0, len(params.AcceptList))
 	)
 
 	for _, v := range params.AcceptList {

--- a/x/oracle/keeper/tally.go
+++ b/x/oracle/keeper/tally.go
@@ -16,6 +16,7 @@ func (k Keeper) BuildClaimsMapAndTally(ctx sdk.Context, params types.Params) err
 
 	// Calculate total validator power
 	var totalBondedValidatorPower int64
+
 	for _, v := range k.StakingKeeper.GetBondedValidatorsByPower(ctx) {
 		addr := v.GetOperator()
 		valConsensusPower := v.GetConsensusPower(powerReduction)
@@ -25,8 +26,8 @@ func (k Keeper) BuildClaimsMapAndTally(ctx sdk.Context, params types.Params) err
 
 	var (
 		// voteTargets defines the symbol (ticker) denoms that we require votes on
-		voteTargets      []string
-		voteTargetDenoms []string
+		voteTargets      = make([]string, len(params.AcceptList))
+		voteTargetDenoms = make([]string, len(params.AcceptList))
 	)
 
 	for _, v := range params.AcceptList {
@@ -41,7 +42,7 @@ func (k Keeper) BuildClaimsMapAndTally(ctx sdk.Context, params types.Params) err
 	// NOTE: **Filter out inactive or jailed validators**
 	ballotDenomSlice := k.OrganizeBallotByDenom(ctx, validatorClaimMap)
 
-	threshold := k.VoteThreshold(ctx).MulInt64(types.MaxVoteThresholdMultiplier).TruncateInt64()
+	threshold := k.GetVoteThreshold(ctx).MulInt64(types.MaxVoteThresholdMultiplier).TruncateInt64()
 
 	// Iterate through ballots and update exchange rates; drop if not enough votes have been achieved.
 	for _, ballotDenom := range ballotDenomSlice {

--- a/x/oracle/keeper/tally.go
+++ b/x/oracle/keeper/tally.go
@@ -12,29 +12,16 @@ func (k Keeper) BuildClaimsMapAndTally(ctx sdk.Context, params types.Params) err
 	// Build claim map over all validators in active set
 	validatorClaimMap := make(map[string]types.Claim)
 
-	maxValidators := k.StakingKeeper.MaxValidators(ctx)
-	iterator := k.StakingKeeper.ValidatorsPowerStoreIterator(ctx)
-
 	powerReduction := k.StakingKeeper.PowerReduction(ctx)
 
-	addedValidators := 0
-	for ; iterator.Valid() && addedValidators < int(maxValidators); iterator.Next() {
-		validator := k.StakingKeeper.Validator(ctx, iterator.Value())
-
-		// Exclude not bonded validator
-		if validator.IsBonded() {
-			valAddr := validator.GetOperator()
-			validatorClaimMap[valAddr.String()] = types.Claim{
-				Power:     validator.GetConsensusPower(powerReduction),
-				Weight:    0,
-				WinCount:  0,
-				Recipient: valAddr,
-			}
-			addedValidators++
-		}
+	// Calculate total validator power
+	var totalBondedValidatorPower int64
+	for _, v := range k.StakingKeeper.GetBondedValidatorsByPower(ctx) {
+		addr := v.GetOperator()
+		valConsensusPower := v.GetConsensusPower(powerReduction)
+		totalBondedValidatorPower += valConsensusPower
+		validatorClaimMap[addr.String()] = types.NewClaim(valConsensusPower, 0, 0, addr)
 	}
-
-	iterator.Close()
 
 	var (
 		// voteTargets defines the symbol (ticker) denoms that we require votes on
@@ -48,17 +35,24 @@ func (k Keeper) BuildClaimsMapAndTally(ctx sdk.Context, params types.Params) err
 	}
 
 	// Clear all exchange rates
-	k.IterateExchangeRates(ctx, func(denom string, _ sdk.Dec) (stop bool) {
-		k.DeleteExchangeRate(ctx, denom)
-		return false
-	})
+	k.ClearExchangeRates(ctx)
 
 	// Organize votes to ballot by denom
 	// NOTE: **Filter out inactive or jailed validators**
 	ballotDenomSlice := k.OrganizeBallotByDenom(ctx, validatorClaimMap)
 
+	threshold := k.VoteThreshold(ctx).MulInt64(types.MaxVoteThresholdMultiplier).TruncateInt64()
+
 	// Iterate through ballots and update exchange rates; drop if not enough votes have been achieved.
 	for _, ballotDenom := range ballotDenomSlice {
+		// Calculate the portion of votes received as an integer, scaled up using the
+		// same multiplier as the `threshold` computed above
+		support := ballotDenom.Ballot.Power() * types.MaxVoteThresholdMultiplier / totalBondedValidatorPower
+		if support < threshold {
+			ctx.Logger().Info("Ballot voting power is under vote threshold, dropping ballot", "denom", ballotDenom)
+			continue
+		}
+
 		// Get weighted median of exchange rates
 		exchangeRate, err := Tally(ballotDenom.Ballot, params.RewardBand, validatorClaimMap)
 		if err != nil {
@@ -93,7 +87,7 @@ func (k Keeper) BuildClaimsMapAndTally(ctx sdk.Context, params types.Params) err
 	)
 
 	// Clear the ballot
-	k.ClearBallots(ctx, params.VotePeriod)
+	k.ClearVotes(ctx, params.VotePeriod)
 
 	return nil
 }

--- a/x/oracle/keeper/tally_test.go
+++ b/x/oracle/keeper/tally_test.go
@@ -133,8 +133,9 @@ func val(n int) sdk.ValAddress {
 	return sdk.ValAddress(fmt.Sprintf("val%08d__________", n))
 }
 
-// TestsBuildClaimsMapAndTally is a test for collection clams map and tallying.
-func (s *KeeperTestSuite) TestBuildClaimsMapAndTally() {
+// TestBuildClaimsMapAndTallyBelowThreshold is a test for collection claims map and tallying for
+// validators votes amount below VoteThreshold.
+func (s *KeeperTestSuite) TestBuildClaimsMapAndTallyBelowThreshold() {
 	// custom app and context for this test
 	app, ctx := s.initAppAndContext()
 
@@ -154,26 +155,103 @@ func (s *KeeperTestSuite) TestBuildClaimsMapAndTally() {
 	params.VotePeriod = 1                            // 10 block
 	params.VoteThreshold = sdk.NewDecWithPrec(50, 2) // 50%
 	params.RewardBand = sdk.NewDecWithPrec(50, 2)    // 50%
+	params.AcceptList = types.DenomList{{
+		BaseDenom:   types.AtomSymbol,
+		SymbolDenom: types.AtomSymbol,
+		Exponent:    6,
+	}}
 	app.OracleKeeper.SetParams(ctx, params)
 
 	// initial exchange rate
-	app.OracleKeeper.SetExchangeRate(ctx, "ATOM", sdk.MustNewDecFromStr("1.0"))
+	app.OracleKeeper.SetExchangeRate(ctx, types.AtomSymbol, sdk.MustNewDecFromStr("1.0"))
 
-	s.T().Log("TestBuildClaimsMapAndTally: 1 vote out of 100 counts (?)")
+	s.T().Log("TestBuildClaimsMapAndTally: 1 vote out of 100 doesn't count (below the threshold of 50%)")
 
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddresses[0], types.NewAggregateExchangeRateVote([]types.ExchangeRateTuple{{
-		Denom: "ATOM", ExchangeRate: sdk.MustNewDecFromStr("999.0"),
+		Denom: types.AtomSymbol, ExchangeRate: sdk.MustNewDecFromStr("999.0"),
 	}}, valAddresses[0]))
 
 	err = app.OracleKeeper.BuildClaimsMapAndTally(ctx, params)
 	s.Require().NoError(err)
 
-	// we haven't reached the vote threshold yet, so no exchange rate update should have happened yet.
-	_, err = app.OracleKeeper.GetExchangeRate(ctx, "ATOM")
-	s.Require().Error(err)
+	// we haven't reached the vote threshold yet, so the exchange rate not updated and is reset
+	_, err = app.OracleKeeper.GetExchangeRate(ctx, types.AtomSymbol)
+	s.Require().ErrorContains(err, types.ErrUnknownDenom.Error())
 
 	// rest of validators marked with misses
-	for i := 1; i < len(valAddresses); i++ {
-		s.Require().Equal(uint64(1), app.OracleKeeper.GetMissCounter(ctx, valAddresses[i]))
+	for valN := 1; valN < len(valAddresses); valN++ {
+		s.Require().Equal(
+			uint64(1),
+			app.OracleKeeper.GetMissCounter(ctx, valAddresses[valN]),
+			fmt.Sprintf("validator: %d", valN),
+		)
+	}
+}
+
+// TestBuildClaimsMapAndTallyAboveThreshold is a test for collection claims map and tallying for
+// validators votes amount up to or above VoteThreshold.
+func (s *KeeperTestSuite) TestBuildClaimsMapAndTallyAboveThreshold() {
+	// custom app and context for this test
+	app, ctx := s.initAppAndContext()
+
+	// generate 100 equal validators in consensus
+	_, valAddresses, err := testutil.StakingAddValidators(
+		app.BankKeeper,
+		app.StakingKeeper,
+		ctx,
+		100,
+	)
+	s.Require().NoError(err)
+	s.Require().Len(valAddresses, 100)
+	s.Require().Equal(100, len(app.StakingKeeper.GetBondedValidatorsByPower(ctx)))
+
+	// override the params with values that are easy for testing
+	params := types.DefaultParams()
+	params.VotePeriod = 1                            // 10 block
+	params.VoteThreshold = sdk.NewDecWithPrec(50, 2) // 50%
+	params.RewardBand = sdk.NewDecWithPrec(50, 2)    // 50%
+	params.AcceptList = types.DenomList{{
+		BaseDenom:   types.AtomDenom,
+		SymbolDenom: types.AtomSymbol,
+		Exponent:    6,
+	}}
+	app.OracleKeeper.SetParams(ctx, params)
+
+	// initial exchange rate
+	app.OracleKeeper.SetExchangeRate(ctx, types.AtomSymbol, sdk.MustNewDecFromStr("1.0"))
+
+	s.T().Log("TestBuildClaimsMapAndTally: >=50 votes out of 100 (above the threshold of 50%)")
+
+	const halfOfBondedValidatorsCount = 50
+
+	for valN := 0; valN < halfOfBondedValidatorsCount; valN++ {
+		app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddresses[valN], types.NewAggregateExchangeRateVote([]types.ExchangeRateTuple{{
+			Denom: types.AtomSymbol, ExchangeRate: sdk.MustNewDecFromStr("999.0"),
+		}}, valAddresses[valN]))
+	}
+
+	err = app.OracleKeeper.BuildClaimsMapAndTally(ctx, params)
+	s.Require().NoError(err)
+
+	// have reached the vote threshold yet, so the exchange rate is updated
+	newRate, err := app.OracleKeeper.GetExchangeRate(ctx, types.AtomSymbol)
+	s.Require().NoError(err)
+	s.Require().EqualValues(sdk.MustNewDecFromStr("999.0"), newRate)
+
+	// first half of validators doesn't have a miss
+	for valN := 0; valN < halfOfBondedValidatorsCount; valN++ {
+		s.Require().Zero(
+			app.OracleKeeper.GetMissCounter(ctx, valAddresses[valN]),
+			fmt.Sprintf("validator: %d", valN),
+		)
+	}
+
+	// rest of validators marked with misses
+	for valN := halfOfBondedValidatorsCount; valN < len(valAddresses); valN++ {
+		s.Require().Equal(
+			uint64(1),
+			app.OracleKeeper.GetMissCounter(ctx, valAddresses[valN]),
+			fmt.Sprintf("validator: %d", valN),
+		)
 	}
 }

--- a/x/oracle/keeper/tally_test.go
+++ b/x/oracle/keeper/tally_test.go
@@ -159,22 +159,21 @@ func (s *KeeperTestSuite) TestBuildClaimsMapAndTally() {
 	// initial exchange rate
 	app.OracleKeeper.SetExchangeRate(ctx, "ATOM", sdk.MustNewDecFromStr("1.0"))
 
-	{
-		s.T().Log("TestBuildClaimsMapAndTally: 1 vote out of 100 counts (?)")
-		app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddresses[0], types.NewAggregateExchangeRateVote([]types.ExchangeRateTuple{{
-			Denom: "ATOM", ExchangeRate: sdk.MustNewDecFromStr("999.0"),
-		}}, valAddresses[0]))
+	s.T().Log("TestBuildClaimsMapAndTally: 1 vote out of 100 counts (?)")
 
-		err = app.OracleKeeper.BuildClaimsMapAndTally(ctx, params)
-		s.Require().NoError(err)
+	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddresses[0], types.NewAggregateExchangeRateVote([]types.ExchangeRateTuple{{
+		Denom: "ATOM", ExchangeRate: sdk.MustNewDecFromStr("999.0"),
+	}}, valAddresses[0]))
 
-		// we haven't reached the vote threshold yet,
-		_, err = app.OracleKeeper.GetExchangeRate(ctx, "ATOM")
-		s.Require().Error(err)
+	err = app.OracleKeeper.BuildClaimsMapAndTally(ctx, params)
+	s.Require().NoError(err)
 
-		// rest of validators marked with misses
-		for i := 1; i < len(valAddresses); i++ {
-			s.Require().Equal(uint64(1), app.OracleKeeper.GetMissCounter(ctx, valAddresses[i]))
-		}
+	// we haven't reached the vote threshold yet, so no exchange rate update should have happened yet.
+	_, err = app.OracleKeeper.GetExchangeRate(ctx, "ATOM")
+	s.Require().Error(err)
+
+	// rest of validators marked with misses
+	for i := 1; i < len(valAddresses); i++ {
+		s.Require().Equal(uint64(1), app.OracleKeeper.GetMissCounter(ctx, valAddresses[i]))
 	}
 }

--- a/x/oracle/testutil/test_helpers.go
+++ b/x/oracle/testutil/test_helpers.go
@@ -48,15 +48,16 @@ func StakingAddValidators(
 	ctx sdk.Context,
 	num int,
 ) (
-	accAddresses []sdk.AccAddress,
-	valAddresses []sdk.ValAddress,
-	err error,
+	[]sdk.AccAddress,
+	[]sdk.ValAddress,
+	error,
 ) {
-	accAddresses = make([]sdk.AccAddress, num)
-	valAddresses = make([]sdk.ValAddress, num)
+	accAddresses := make([]sdk.AccAddress, num)
+	valAddresses := make([]sdk.ValAddress, num)
 	stakingHandler := staking.NewHandler(stakingKeeper)
 
 	valPubKeys := simapp.CreateTestPubKeys(num)
+
 	for i := 0; i < num; i++ {
 		var (
 			valPubKey = valPubKeys[i]
@@ -86,7 +87,8 @@ func StakingAddValidators(
 
 	// ensure that validators are updated
 	staking.EndBlocker(ctx, stakingKeeper)
-	return
+
+	return accAddresses, valAddresses, nil
 }
 
 func newTestMsgCreateValidator(address sdk.ValAddress, pubKey cryptotypes.PubKey, amt sdk.Int) (*stakingtypes.MsgCreateValidator, error) {

--- a/x/oracle/types/ballot.go
+++ b/x/oracle/types/ballot.go
@@ -60,6 +60,7 @@ func (pb ExchangeRateBallot) WeightedMedian() (sdk.Dec, error) {
 
 	if pb.Len() > 0 {
 		totalPower := pb.Power()
+
 		var pivot int64
 
 		for _, v := range pb {

--- a/x/oracle/types/ballot.go
+++ b/x/oracle/types/ballot.go
@@ -58,9 +58,8 @@ func (pb ExchangeRateBallot) WeightedMedian() (sdk.Dec, error) {
 		return sdk.ZeroDec(), ErrBallotNotSorted
 	}
 
-	totalPower := pb.Power()
-
 	if pb.Len() > 0 {
+		totalPower := pb.Power()
 		var pivot int64
 
 		for _, v := range pb {

--- a/x/oracle/types/expected_keeper.go
+++ b/x/oracle/types/expected_keeper.go
@@ -11,6 +11,7 @@ import (
 // module.
 type StakingKeeper interface {
 	Validator(ctx sdk.Context, address sdk.ValAddress) stakingtypes.ValidatorI
+	GetBondedValidatorsByPower(ctx sdk.Context) []stakingtypes.Validator
 	TotalBondedTokens(sdk.Context) sdk.Int
 	Slash(sdk.Context, sdk.ConsAddress, int64, int64, sdk.Dec)
 	Jail(sdk.Context, sdk.ConsAddress)

--- a/x/oracle/types/params.go
+++ b/x/oracle/types/params.go
@@ -93,7 +93,7 @@ func (p *Params) ParamSetPairs() paramstypes.ParamSetPairs {
 		paramstypes.NewParamSetPair(
 			KeyVoteThreshold,
 			&p.VoteThreshold,
-			ValidateVoteThreshold,
+			validateVoteThreshold,
 		),
 		paramstypes.NewParamSetPair(
 			KeyRewardBand,
@@ -140,7 +140,7 @@ func (p Params) Validate() error {
 		return fmt.Errorf("oracle parameter VotePeriod must be > 0, is %d", p.VotePeriod)
 	}
 
-	if p.VoteThreshold.LTE(sdk.NewDecWithPrec(33, 2)) {
+	if p.VoteThreshold.LTE(minVoteThreshold) {
 		return fmt.Errorf("oracle parameter VoteThreshold must be greater than 33 percent")
 	}
 
@@ -190,11 +190,11 @@ func validateVotePeriod(i interface{}) error {
 	return nil
 }
 
-// ValidateVoteThreshold validates oracle exchange rates power vote threshold.
+// validateVoteThreshold validates oracle exchange rates power vote threshold.
 // Must be
 // * a decimal value > 0.33 and <= 1.
 // * max precision is 2 (so 0.501 is not allowed)
-func ValidateVoteThreshold(i interface{}) error {
+func validateVoteThreshold(i interface{}) error {
 	v, ok := i.(sdk.Dec)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -206,6 +206,7 @@ func ValidateVoteThreshold(i interface{}) error {
 
 	val := v.MulInt64(MaxVoteThresholdMultiplier).TruncateInt64()
 	x2 := sdk.NewDecWithPrec(val, MaxVoteThresholdPrecision)
+
 	if !x2.Equal(v) {
 		return sdkerrors.ErrInvalidRequest.Wrap("threshold precision must be maximum 2 decimals")
 	}

--- a/x/oracle/types/params_test.go
+++ b/x/oracle/types/params_test.go
@@ -23,17 +23,37 @@ func TestValidateVotePeriod(t *testing.T) {
 }
 
 func TestValidateVoteThreshold(t *testing.T) {
-	err := validateVoteThreshold("invalidSdkType")
-	require.ErrorContains(t, err, "invalid parameter type: string")
+	testCases := []struct {
+		name      string
+		threshold interface{}
+		errMsg    string
+	}{
+		{"fail: invalid parameter", "invalidSdkType", "invalid parameter type"},
+		{"fail: negative", sdk.MustNewDecFromStr("-1"), "threshold must be"},
+		{"fail: zero", sdk.ZeroDec(), "threshold must be"},
+		{"fail: less than 0.33", sdk.MustNewDecFromStr("0.3"), "threshold must be"},
+		{"fail: equal 0.33", sdk.MustNewDecFromStr("0.33"), "threshold must be"},
+		{"fail: more than 1", sdk.MustNewDecFromStr("1.1"), "threshold must be"},
+		{"fail: more than 1", sdk.MustNewDecFromStr("10"), "threshold must be"},
+		{"fail: max precision 2", sdk.MustNewDecFromStr("0.333"), "maximum 2 decimals"},
+		{"fail: max precision 2", sdk.MustNewDecFromStr("0.401"), "maximum 2 decimals"},
+		{"fail: max precision 2", sdk.MustNewDecFromStr("0.409"), "maximum 2 decimals"},
+		{"fail: max precision 2", sdk.MustNewDecFromStr("0.4009"), "maximum 2 decimals"},
+		{"fail: max precision 2", sdk.MustNewDecFromStr("0.999"), "maximum 2 decimals"},
 
-	err = validateVoteThreshold(sdk.MustNewDecFromStr("0.31"))
-	require.ErrorContains(t, err, "vote threshold must be bigger than 33%: 0.310000000000000000")
+		{"ok: 1", sdk.MustNewDecFromStr("1"), ""},
+		{"ok: 0.34", sdk.MustNewDecFromStr("0.34"), ""},
+		{"ok: 0.99", sdk.MustNewDecFromStr("0.99"), ""},
+	}
 
-	err = validateVoteThreshold(sdk.MustNewDecFromStr("40.0"))
-	require.ErrorContains(t, err, "vote threshold too large: 40.000000000000000000")
-
-	err = validateVoteThreshold(sdk.MustNewDecFromStr("0.35"))
-	require.Nil(t, err)
+	for _, tc := range testCases {
+		err := ValidateVoteThreshold(tc.threshold)
+		if tc.errMsg == "" {
+			require.NoError(t, err, "test_case", tc.name)
+		} else {
+			require.ErrorContains(t, err, tc.errMsg, tc.name)
+		}
+	}
 }
 
 func TestValidateRewardBand(t *testing.T) {

--- a/x/oracle/types/params_test.go
+++ b/x/oracle/types/params_test.go
@@ -47,7 +47,7 @@ func TestValidateVoteThreshold(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		err := ValidateVoteThreshold(tc.threshold)
+		err := validateVoteThreshold(tc.threshold)
 		if tc.errMsg == "" {
 			require.NoError(t, err, "test_case", tc.name)
 		} else {


### PR DESCRIPTION
## 1. Overview

- Filter out the exchange rates which have votes below the vote threshold `< 50%`.

- Remove the `ValidatorsPowerStoreIterator` and instead use `GetBondedValidatorsByPower`.

- Refactor.