### PR TITLE
feat: update oracle exchange rate query

### DIFF
--- a/proto/persistence/oracle/v1beta1/query.proto
+++ b/proto/persistence/oracle/v1beta1/query.proto
@@ -11,10 +11,14 @@ option go_package = "github.com/persistenceOne/persistence-sdk/v2/x/oracle/types
 
 // Query defines the gRPC querier service.
 service Query {
-  // ExchangeRates returns exchange rates of all denoms,
-  // or, if specified, returns a single denom
-  rpc ExchangeRates(QueryExchangeRatesRequest) returns (QueryExchangeRatesResponse) {
-    option (google.api.http).get = "/persistence/oracle/v1beta1/denoms/exchange_rates/{denom}";
+  // ExchangeRates returns exchange rates of all denoms.
+  rpc AllExchangeRates(QueryAllExchangeRatesRequest) returns (QueryAllExchangeRatesResponse) {
+    option (google.api.http).get = "/persistence/oracle/v1beta1/denoms/all_exchange_rates";
+  }
+
+  // ExchangeRate returns exchange rates of a specified denom.
+  rpc ExchangeRate(QueryExchangeRateRequest) returns (QueryExchangeRateResponse) {
+    option (google.api.http).get = "/persistence/oracle/v1beta1/denoms/exchange_rate/{denom}";
   }
 
   // ActiveExchangeRates returns all active denoms
@@ -63,9 +67,9 @@ service Query {
   }
 }
 
-// QueryExchangeRatesRequest is the request type for the Query/ExchangeRate RPC
+// QueryExchangeRateRequest is the request type for the Query/ExchangeRate RPC
 // method.
-message QueryExchangeRatesRequest {
+message QueryExchangeRateRequest {
   option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
@@ -73,16 +77,28 @@ message QueryExchangeRatesRequest {
   string denom = 1;
 }
 
+// QueryExchangeRateResponse is the request type for the Query/ExchangeRate RPC
+// method.
+message QueryExchangeRateResponse {
+  option (gogoproto.equal)           = false;
+  option (gogoproto.goproto_getters) = false;
 
-// QueryExchangeRatesResponse is response type for the
+  // denom defines the denomination to query for.
+  string exchange_rate = 1;
+}
+
+// QueryAllExchangeRatesRequest is the request type for the Query/ExchangeRate RPC
+// method.
+message QueryAllExchangeRatesRequest {}
+
+// QueryAllExchangeRatesResponse is response type for the
 // Query/ExchangeRates RPC method.
-message QueryExchangeRatesResponse {
+message QueryAllExchangeRatesResponse {
   // exchange_rates defines a list of the exchange rate for all whitelisted
   // denoms.
   repeated cosmos.base.v1beta1.DecCoin exchange_rates = 1
-      [(gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.DecCoins", (gogoproto.nullable) = false];
+  [(gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.DecCoins", (gogoproto.nullable) = false];
 }
-
 
 // QueryActiveExchangeRatesRequest is the request type for the Query/ActiveExchangeRates RPC method.
 message QueryActiveExchangeRatesRequest {}

--- a/x/oracle/client/cli/query.go
+++ b/x/oracle/client/cli/query.go
@@ -26,7 +26,7 @@ func GetQueryCmd(queryRoute string) *cobra.Command {
 		GetCmdQueryAggregatePrevote(),
 		GetCmdQueryAggregateVote(),
 		GetCmdQueryParams(),
-		GetCmdQueryExchangeRates(),
+		GetCmdQueryAllExchangeRates(),
 		GetCmdQueryExchangeRate(),
 		GetCmdQueryFeederDelegation(),
 		GetCmdQueryRewardPoolBalance(),
@@ -145,8 +145,8 @@ func GetCmdQueryAggregatePrevote() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryExchangeRates implements the query rate command.
-func GetCmdQueryExchangeRates() *cobra.Command {
+// GetCmdQueryAllExchangeRates implements the query all exchange rate command.
+func GetCmdQueryAllExchangeRates() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "exchange-rates",
 		Args:  cobra.NoArgs,
@@ -158,9 +158,9 @@ func GetCmdQueryExchangeRates() *cobra.Command {
 			}
 			queryClient := types.NewQueryClient(clientCtx)
 
-			res, err := queryClient.ExchangeRates(
+			res, err := queryClient.AllExchangeRates(
 				context.Background(),
-				&types.QueryExchangeRatesRequest{},
+				&types.QueryAllExchangeRatesRequest{},
 			)
 			if err != nil {
 				return err
@@ -175,7 +175,7 @@ func GetCmdQueryExchangeRates() *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryExchangeRates implements the query rate command.
+// GetCmdQueryExchangeRates implements the query specified exchange rate command.
 func GetCmdQueryExchangeRate() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "exchange-rate [denom]",
@@ -188,10 +188,15 @@ func GetCmdQueryExchangeRate() *cobra.Command {
 			}
 			queryClient := types.NewQueryClient(clientCtx)
 
-			res, err := queryClient.ExchangeRates(
+			symbol := args[0]
+			if "" == symbol {
+				return fmt.Errorf("denom cannot be empty")
+			}
+
+			res, err := queryClient.ExchangeRate(
 				context.Background(),
-				&types.QueryExchangeRatesRequest{
-					Denom: args[0],
+				&types.QueryExchangeRateRequest{
+					Denom: symbol,
 				},
 			)
 			if err != nil {

--- a/x/oracle/client/cli/query.go
+++ b/x/oracle/client/cli/query.go
@@ -189,7 +189,7 @@ func GetCmdQueryExchangeRate() *cobra.Command {
 			queryClient := types.NewQueryClient(clientCtx)
 
 			symbol := args[0]
-			if "" == symbol {
+			if symbol == "" {
 				return fmt.Errorf("denom cannot be empty")
 			}
 

--- a/x/oracle/keeper/grpc_query_test.go
+++ b/x/oracle/keeper/grpc_query_test.go
@@ -1,0 +1,41 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/persistenceOne/persistence-sdk/v2/x/oracle/types"
+)
+
+func (s *KeeperTestSuite) TestQueryExchangeRate() {
+	// Check that querying exchange rate on default genesis returns error.
+	// Since no exchange rate is set.
+	resp, err := s.queryClient.ExchangeRate(s.ctx.Context(), &types.QueryExchangeRateRequest{})
+	s.Require().Error(err)
+	s.Require().Nil(resp)
+
+	// Set exchange rate for XPRT.
+	s.app.OracleKeeper.SetExchangeRate(s.ctx, types.PersistenceSymbol, sdk.OneDec())
+
+	resp, err = s.queryClient.ExchangeRate(s.ctx.Context(), &types.QueryExchangeRateRequest{Denom: types.PersistenceSymbol})
+	s.Require().NoError(err)
+	s.Require().Equal(resp.ExchangeRate, sdk.OneDec().String())
+}
+
+func (s *KeeperTestSuite) TestQueryAllExchangeRate() {
+	// Check that querying all exchange rates on default genesis returns empty list.
+	resp, err := s.queryClient.AllExchangeRates(s.ctx.Context(), &types.QueryAllExchangeRatesRequest{})
+	s.Require().NoError(err)
+	s.Require().Nil(resp.ExchangeRates)
+
+	// Set exchange rate for XPRT.
+	s.app.OracleKeeper.SetExchangeRate(s.ctx, types.PersistenceSymbol, sdk.OneDec())
+	// Set exchange rate for ATOM.
+	s.app.OracleKeeper.SetExchangeRate(s.ctx, types.AtomSymbol, sdk.OneDec())
+	// Set exchange rate for OSMO.
+	s.app.OracleKeeper.SetExchangeRate(s.ctx, types.OsmosisSymbol, sdk.OneDec())
+	// Set exchange rate for USDC.
+	s.app.OracleKeeper.SetExchangeRate(s.ctx, types.USDCSymbol, sdk.OneDec())
+
+	resp, err = s.queryClient.AllExchangeRates(s.ctx.Context(), &types.QueryAllExchangeRatesRequest{})
+	s.Require().NoError(err)
+	s.Require().Len(resp.ExchangeRates, 4)
+}

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	"github.com/stretchr/testify/suite"
@@ -24,9 +25,10 @@ type KeeperTestSuite struct {
 	accAddresses []sdk.AccAddress
 	valAddresses []sdk.ValAddress
 
-	ctx       sdk.Context
-	app       *persistenceapp.SimApp
-	msgServer types.MsgServer
+	ctx         sdk.Context
+	app         *persistenceapp.SimApp
+	queryClient types.QueryClient
+	msgServer   types.MsgServer
 }
 
 const (
@@ -50,6 +52,12 @@ func (s *KeeperTestSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.msgServer = keeper.NewMsgServerImpl(s.app.OracleKeeper)
+	queryHelper := &baseapp.QueryServiceTestHelper{
+		GRPCQueryRouter: s.app.GRPCQueryRouter(),
+		Ctx:             s.ctx,
+	}
+
+	s.queryClient = types.NewQueryClient(queryHelper)
 }
 
 func (s *KeeperTestSuite) initAppAndContext() (app *persistenceapp.SimApp, ctx sdk.Context) {

--- a/x/oracle/types/asset.go
+++ b/x/oracle/types/asset.go
@@ -22,15 +22,15 @@ const (
 	AtomSymbol   string = "ATOM"
 	AtomExponent        = uint32(6)
 
-	// osmosisDenom supported by oracle
-	osmosisDenom    string = "uosmo"
-	osmosisSymbol   string = "OSMO"
-	osmosisExponent        = uint32(6)
+	// OsmosisDenom supported by oracle
+	OsmosisDenom    string = "uosmo"
+	OsmosisSymbol   string = "OSMO"
+	OsmosisExponent        = uint32(6)
 
 	// USDCDenom supported by oracle
-	usdcDenom    string = "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
-	usdcSymbol   string = "USDC"
-	usdcExponent        = uint32(6)
+	USDCDenom    string = "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+	USDCSymbol   string = "USDC"
+	UsdcExponent        = uint32(6)
 )
 
 type (

--- a/x/oracle/types/params.go
+++ b/x/oracle/types/params.go
@@ -43,14 +43,14 @@ var (
 			Exponent:    AtomExponent,
 		},
 		{
-			BaseDenom:   osmosisDenom,
-			SymbolDenom: osmosisSymbol,
-			Exponent:    osmosisExponent,
+			BaseDenom:   OsmosisDenom,
+			SymbolDenom: OsmosisSymbol,
+			Exponent:    OsmosisExponent,
 		},
 		{
-			BaseDenom:   usdcDenom,
-			SymbolDenom: usdcSymbol,
-			Exponent:    usdcExponent,
+			BaseDenom:   USDCDenom,
+			SymbolDenom: USDCSymbol,
+			Exponent:    UsdcExponent,
 		},
 	}
 	DefaultSlashFraction     = sdk.NewDecWithPrec(1, 4) // 0.01%

--- a/x/oracle/types/query.pb.go
+++ b/x/oracle/types/query.pb.go
@@ -32,25 +32,25 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// QueryExchangeRatesRequest is the request type for the Query/ExchangeRate RPC
+// QueryExchangeRateRequest is the request type for the Query/ExchangeRate RPC
 // method.
-type QueryExchangeRatesRequest struct {
+type QueryExchangeRateRequest struct {
 	// denom defines the denomination to query for.
 	Denom string `protobuf:"bytes,1,opt,name=denom,proto3" json:"denom,omitempty"`
 }
 
-func (m *QueryExchangeRatesRequest) Reset()         { *m = QueryExchangeRatesRequest{} }
-func (m *QueryExchangeRatesRequest) String() string { return proto.CompactTextString(m) }
-func (*QueryExchangeRatesRequest) ProtoMessage()    {}
-func (*QueryExchangeRatesRequest) Descriptor() ([]byte, []int) {
+func (m *QueryExchangeRateRequest) Reset()         { *m = QueryExchangeRateRequest{} }
+func (m *QueryExchangeRateRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryExchangeRateRequest) ProtoMessage()    {}
+func (*QueryExchangeRateRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_45ea8e3c157a904c, []int{0}
 }
-func (m *QueryExchangeRatesRequest) XXX_Unmarshal(b []byte) error {
+func (m *QueryExchangeRateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *QueryExchangeRatesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *QueryExchangeRateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_QueryExchangeRatesRequest.Marshal(b, m, deterministic)
+		return xxx_messageInfo_QueryExchangeRateRequest.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -60,38 +60,116 @@ func (m *QueryExchangeRatesRequest) XXX_Marshal(b []byte, deterministic bool) ([
 		return b[:n], nil
 	}
 }
-func (m *QueryExchangeRatesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_QueryExchangeRatesRequest.Merge(m, src)
+func (m *QueryExchangeRateRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryExchangeRateRequest.Merge(m, src)
 }
-func (m *QueryExchangeRatesRequest) XXX_Size() int {
+func (m *QueryExchangeRateRequest) XXX_Size() int {
 	return m.Size()
 }
-func (m *QueryExchangeRatesRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_QueryExchangeRatesRequest.DiscardUnknown(m)
+func (m *QueryExchangeRateRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryExchangeRateRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_QueryExchangeRatesRequest proto.InternalMessageInfo
+var xxx_messageInfo_QueryExchangeRateRequest proto.InternalMessageInfo
 
-// QueryExchangeRatesResponse is response type for the
+// QueryExchangeRateResponse is the request type for the Query/ExchangeRate RPC
+// method.
+type QueryExchangeRateResponse struct {
+	// denom defines the denomination to query for.
+	ExchangeRate string `protobuf:"bytes,1,opt,name=exchange_rate,json=exchangeRate,proto3" json:"exchange_rate,omitempty"`
+}
+
+func (m *QueryExchangeRateResponse) Reset()         { *m = QueryExchangeRateResponse{} }
+func (m *QueryExchangeRateResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryExchangeRateResponse) ProtoMessage()    {}
+func (*QueryExchangeRateResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_45ea8e3c157a904c, []int{1}
+}
+func (m *QueryExchangeRateResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryExchangeRateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryExchangeRateResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryExchangeRateResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryExchangeRateResponse.Merge(m, src)
+}
+func (m *QueryExchangeRateResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryExchangeRateResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryExchangeRateResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryExchangeRateResponse proto.InternalMessageInfo
+
+// QueryAllExchangeRatesRequest is the request type for the Query/ExchangeRate RPC
+// method.
+type QueryAllExchangeRatesRequest struct {
+}
+
+func (m *QueryAllExchangeRatesRequest) Reset()         { *m = QueryAllExchangeRatesRequest{} }
+func (m *QueryAllExchangeRatesRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryAllExchangeRatesRequest) ProtoMessage()    {}
+func (*QueryAllExchangeRatesRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_45ea8e3c157a904c, []int{2}
+}
+func (m *QueryAllExchangeRatesRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryAllExchangeRatesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryAllExchangeRatesRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryAllExchangeRatesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryAllExchangeRatesRequest.Merge(m, src)
+}
+func (m *QueryAllExchangeRatesRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryAllExchangeRatesRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryAllExchangeRatesRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryAllExchangeRatesRequest proto.InternalMessageInfo
+
+// QueryAllExchangeRatesResponse is response type for the
 // Query/ExchangeRates RPC method.
-type QueryExchangeRatesResponse struct {
+type QueryAllExchangeRatesResponse struct {
 	// exchange_rates defines a list of the exchange rate for all whitelisted
 	// denoms.
 	ExchangeRates github_com_cosmos_cosmos_sdk_types.DecCoins `protobuf:"bytes,1,rep,name=exchange_rates,json=exchangeRates,proto3,castrepeated=github.com/cosmos/cosmos-sdk/types.DecCoins" json:"exchange_rates"`
 }
 
-func (m *QueryExchangeRatesResponse) Reset()         { *m = QueryExchangeRatesResponse{} }
-func (m *QueryExchangeRatesResponse) String() string { return proto.CompactTextString(m) }
-func (*QueryExchangeRatesResponse) ProtoMessage()    {}
-func (*QueryExchangeRatesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{1}
+func (m *QueryAllExchangeRatesResponse) Reset()         { *m = QueryAllExchangeRatesResponse{} }
+func (m *QueryAllExchangeRatesResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryAllExchangeRatesResponse) ProtoMessage()    {}
+func (*QueryAllExchangeRatesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_45ea8e3c157a904c, []int{3}
 }
-func (m *QueryExchangeRatesResponse) XXX_Unmarshal(b []byte) error {
+func (m *QueryAllExchangeRatesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *QueryExchangeRatesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *QueryAllExchangeRatesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_QueryExchangeRatesResponse.Marshal(b, m, deterministic)
+		return xxx_messageInfo_QueryAllExchangeRatesResponse.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -101,19 +179,19 @@ func (m *QueryExchangeRatesResponse) XXX_Marshal(b []byte, deterministic bool) (
 		return b[:n], nil
 	}
 }
-func (m *QueryExchangeRatesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_QueryExchangeRatesResponse.Merge(m, src)
+func (m *QueryAllExchangeRatesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryAllExchangeRatesResponse.Merge(m, src)
 }
-func (m *QueryExchangeRatesResponse) XXX_Size() int {
+func (m *QueryAllExchangeRatesResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *QueryExchangeRatesResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_QueryExchangeRatesResponse.DiscardUnknown(m)
+func (m *QueryAllExchangeRatesResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryAllExchangeRatesResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_QueryExchangeRatesResponse proto.InternalMessageInfo
+var xxx_messageInfo_QueryAllExchangeRatesResponse proto.InternalMessageInfo
 
-func (m *QueryExchangeRatesResponse) GetExchangeRates() github_com_cosmos_cosmos_sdk_types.DecCoins {
+func (m *QueryAllExchangeRatesResponse) GetExchangeRates() github_com_cosmos_cosmos_sdk_types.DecCoins {
 	if m != nil {
 		return m.ExchangeRates
 	}
@@ -128,7 +206,7 @@ func (m *QueryActiveExchangeRatesRequest) Reset()         { *m = QueryActiveExch
 func (m *QueryActiveExchangeRatesRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryActiveExchangeRatesRequest) ProtoMessage()    {}
 func (*QueryActiveExchangeRatesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{2}
+	return fileDescriptor_45ea8e3c157a904c, []int{4}
 }
 func (m *QueryActiveExchangeRatesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -169,7 +247,7 @@ func (m *QueryActiveExchangeRatesResponse) Reset()         { *m = QueryActiveExc
 func (m *QueryActiveExchangeRatesResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryActiveExchangeRatesResponse) ProtoMessage()    {}
 func (*QueryActiveExchangeRatesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{3}
+	return fileDescriptor_45ea8e3c157a904c, []int{5}
 }
 func (m *QueryActiveExchangeRatesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -216,7 +294,7 @@ func (m *QueryFeederDelegationRequest) Reset()         { *m = QueryFeederDelegat
 func (m *QueryFeederDelegationRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryFeederDelegationRequest) ProtoMessage()    {}
 func (*QueryFeederDelegationRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{4}
+	return fileDescriptor_45ea8e3c157a904c, []int{6}
 }
 func (m *QueryFeederDelegationRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -256,7 +334,7 @@ func (m *QueryFeederDelegationResponse) Reset()         { *m = QueryFeederDelega
 func (m *QueryFeederDelegationResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryFeederDelegationResponse) ProtoMessage()    {}
 func (*QueryFeederDelegationResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{5}
+	return fileDescriptor_45ea8e3c157a904c, []int{7}
 }
 func (m *QueryFeederDelegationResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -303,7 +381,7 @@ func (m *QueryMissCounterRequest) Reset()         { *m = QueryMissCounterRequest
 func (m *QueryMissCounterRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryMissCounterRequest) ProtoMessage()    {}
 func (*QueryMissCounterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{6}
+	return fileDescriptor_45ea8e3c157a904c, []int{8}
 }
 func (m *QueryMissCounterRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -343,7 +421,7 @@ func (m *QueryMissCounterResponse) Reset()         { *m = QueryMissCounterRespon
 func (m *QueryMissCounterResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryMissCounterResponse) ProtoMessage()    {}
 func (*QueryMissCounterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{7}
+	return fileDescriptor_45ea8e3c157a904c, []int{9}
 }
 func (m *QueryMissCounterResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -390,7 +468,7 @@ func (m *QueryAggregatePrevoteRequest) Reset()         { *m = QueryAggregatePrev
 func (m *QueryAggregatePrevoteRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryAggregatePrevoteRequest) ProtoMessage()    {}
 func (*QueryAggregatePrevoteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{8}
+	return fileDescriptor_45ea8e3c157a904c, []int{10}
 }
 func (m *QueryAggregatePrevoteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -431,7 +509,7 @@ func (m *QueryAggregatePrevoteResponse) Reset()         { *m = QueryAggregatePre
 func (m *QueryAggregatePrevoteResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryAggregatePrevoteResponse) ProtoMessage()    {}
 func (*QueryAggregatePrevoteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{9}
+	return fileDescriptor_45ea8e3c157a904c, []int{11}
 }
 func (m *QueryAggregatePrevoteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -476,7 +554,7 @@ func (m *QueryAggregatePrevotesRequest) Reset()         { *m = QueryAggregatePre
 func (m *QueryAggregatePrevotesRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryAggregatePrevotesRequest) ProtoMessage()    {}
 func (*QueryAggregatePrevotesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{10}
+	return fileDescriptor_45ea8e3c157a904c, []int{12}
 }
 func (m *QueryAggregatePrevotesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -517,7 +595,7 @@ func (m *QueryAggregatePrevotesResponse) Reset()         { *m = QueryAggregatePr
 func (m *QueryAggregatePrevotesResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryAggregatePrevotesResponse) ProtoMessage()    {}
 func (*QueryAggregatePrevotesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{11}
+	return fileDescriptor_45ea8e3c157a904c, []int{13}
 }
 func (m *QueryAggregatePrevotesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -564,7 +642,7 @@ func (m *QueryAggregateVoteRequest) Reset()         { *m = QueryAggregateVoteReq
 func (m *QueryAggregateVoteRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryAggregateVoteRequest) ProtoMessage()    {}
 func (*QueryAggregateVoteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{12}
+	return fileDescriptor_45ea8e3c157a904c, []int{14}
 }
 func (m *QueryAggregateVoteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -605,7 +683,7 @@ func (m *QueryAggregateVoteResponse) Reset()         { *m = QueryAggregateVoteRe
 func (m *QueryAggregateVoteResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryAggregateVoteResponse) ProtoMessage()    {}
 func (*QueryAggregateVoteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{13}
+	return fileDescriptor_45ea8e3c157a904c, []int{15}
 }
 func (m *QueryAggregateVoteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -650,7 +728,7 @@ func (m *QueryAggregateVotesRequest) Reset()         { *m = QueryAggregateVotesR
 func (m *QueryAggregateVotesRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryAggregateVotesRequest) ProtoMessage()    {}
 func (*QueryAggregateVotesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{14}
+	return fileDescriptor_45ea8e3c157a904c, []int{16}
 }
 func (m *QueryAggregateVotesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -691,7 +769,7 @@ func (m *QueryAggregateVotesResponse) Reset()         { *m = QueryAggregateVotes
 func (m *QueryAggregateVotesResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryAggregateVotesResponse) ProtoMessage()    {}
 func (*QueryAggregateVotesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{15}
+	return fileDescriptor_45ea8e3c157a904c, []int{17}
 }
 func (m *QueryAggregateVotesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -735,7 +813,7 @@ func (m *QueryParamsRequest) Reset()         { *m = QueryParamsRequest{} }
 func (m *QueryParamsRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryParamsRequest) ProtoMessage()    {}
 func (*QueryParamsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{16}
+	return fileDescriptor_45ea8e3c157a904c, []int{18}
 }
 func (m *QueryParamsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -774,7 +852,7 @@ func (m *QueryParamsResponse) Reset()         { *m = QueryParamsResponse{} }
 func (m *QueryParamsResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryParamsResponse) ProtoMessage()    {}
 func (*QueryParamsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{17}
+	return fileDescriptor_45ea8e3c157a904c, []int{19}
 }
 func (m *QueryParamsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -817,7 +895,7 @@ func (m *QueryRewardPoolBalanceRequest) Reset()         { *m = QueryRewardPoolBa
 func (m *QueryRewardPoolBalanceRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryRewardPoolBalanceRequest) ProtoMessage()    {}
 func (*QueryRewardPoolBalanceRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{18}
+	return fileDescriptor_45ea8e3c157a904c, []int{20}
 }
 func (m *QueryRewardPoolBalanceRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -855,7 +933,7 @@ func (m *QueryRewardPoolBalanceResponse) Reset()         { *m = QueryRewardPoolB
 func (m *QueryRewardPoolBalanceResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryRewardPoolBalanceResponse) ProtoMessage()    {}
 func (*QueryRewardPoolBalanceResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_45ea8e3c157a904c, []int{19}
+	return fileDescriptor_45ea8e3c157a904c, []int{21}
 }
 func (m *QueryRewardPoolBalanceResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -892,8 +970,10 @@ func (m *QueryRewardPoolBalanceResponse) GetRemainingFunds() github_com_cosmos_c
 }
 
 func init() {
-	proto.RegisterType((*QueryExchangeRatesRequest)(nil), "persistence.oracle.v1beta1.QueryExchangeRatesRequest")
-	proto.RegisterType((*QueryExchangeRatesResponse)(nil), "persistence.oracle.v1beta1.QueryExchangeRatesResponse")
+	proto.RegisterType((*QueryExchangeRateRequest)(nil), "persistence.oracle.v1beta1.QueryExchangeRateRequest")
+	proto.RegisterType((*QueryExchangeRateResponse)(nil), "persistence.oracle.v1beta1.QueryExchangeRateResponse")
+	proto.RegisterType((*QueryAllExchangeRatesRequest)(nil), "persistence.oracle.v1beta1.QueryAllExchangeRatesRequest")
+	proto.RegisterType((*QueryAllExchangeRatesResponse)(nil), "persistence.oracle.v1beta1.QueryAllExchangeRatesResponse")
 	proto.RegisterType((*QueryActiveExchangeRatesRequest)(nil), "persistence.oracle.v1beta1.QueryActiveExchangeRatesRequest")
 	proto.RegisterType((*QueryActiveExchangeRatesResponse)(nil), "persistence.oracle.v1beta1.QueryActiveExchangeRatesResponse")
 	proto.RegisterType((*QueryFeederDelegationRequest)(nil), "persistence.oracle.v1beta1.QueryFeederDelegationRequest")
@@ -919,76 +999,80 @@ func init() {
 }
 
 var fileDescriptor_45ea8e3c157a904c = []byte{
-	// 1097 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x57, 0x41, 0x6f, 0x1b, 0x45,
-	0x14, 0xf6, 0x40, 0x1b, 0xd1, 0x31, 0x76, 0x92, 0x69, 0x04, 0x89, 0x09, 0xeb, 0x74, 0x85, 0x20,
-	0x02, 0xba, 0x4b, 0x93, 0x52, 0xd2, 0xa4, 0x84, 0xc4, 0x4d, 0x23, 0x10, 0x02, 0xd2, 0x45, 0x14,
-	0x89, 0x8b, 0x35, 0xde, 0x9d, 0x6c, 0x57, 0xb5, 0x77, 0xdc, 0x9d, 0xb5, 0x49, 0x55, 0x55, 0x42,
-	0x70, 0xe1, 0x80, 0x04, 0x12, 0x82, 0x73, 0xcf, 0x9c, 0x39, 0x23, 0xf5, 0x80, 0xd4, 0x0b, 0x50,
-	0x15, 0x21, 0x21, 0x0e, 0x80, 0x12, 0x0e, 0xfc, 0x8c, 0x6a, 0x67, 0x66, 0xd7, 0xbb, 0xf6, 0xae,
-	0xbd, 0x76, 0x95, 0x53, 0xb2, 0xf3, 0xde, 0x9b, 0xf7, 0x7d, 0xef, 0xcd, 0xbc, 0x6f, 0x0c, 0x5f,
-	0x6c, 0x13, 0x8f, 0x39, 0xcc, 0x27, 0xae, 0x49, 0x74, 0xea, 0x61, 0xb3, 0x49, 0xf4, 0xee, 0xb9,
-	0x06, 0xf1, 0xf1, 0x39, 0xfd, 0x66, 0x87, 0x78, 0xb7, 0xb4, 0xb6, 0x47, 0x7d, 0x8a, 0x2a, 0x31,
-	0x3f, 0x4d, 0xf8, 0x69, 0xd2, 0xaf, 0x32, 0x67, 0x53, 0x9b, 0x72, 0x37, 0x3d, 0xf8, 0x4f, 0x44,
-	0x54, 0x16, 0x6d, 0x4a, 0xed, 0x26, 0xd1, 0x71, 0xdb, 0xd1, 0xb1, 0xeb, 0x52, 0x1f, 0xfb, 0x0e,
-	0x75, 0x99, 0xb4, 0xbe, 0x34, 0x24, 0xaf, 0xdc, 0x5e, 0x38, 0x2a, 0x26, 0x65, 0x2d, 0xca, 0xf4,
-	0x06, 0x66, 0x3d, 0x0f, 0x93, 0x3a, 0xae, 0xb4, 0x2f, 0x08, 0x7b, 0x5d, 0xe4, 0x17, 0x1f, 0xc2,
-	0xa4, 0x6e, 0xc0, 0x85, 0xab, 0x01, 0x85, 0x2b, 0x07, 0xe6, 0x75, 0xec, 0xda, 0xc4, 0xc0, 0x3e,
-	0x61, 0x06, 0xb9, 0xd9, 0x21, 0xcc, 0x47, 0x73, 0xf0, 0xa4, 0x45, 0x5c, 0xda, 0x9a, 0x07, 0x4b,
-	0x60, 0xf9, 0x94, 0x21, 0x3e, 0xd6, 0x9f, 0xfa, 0xf2, 0x6e, 0xb5, 0xf0, 0xff, 0xdd, 0x6a, 0x41,
-	0xfd, 0x1e, 0xc0, 0x4a, 0x5a, 0x34, 0x6b, 0x53, 0x97, 0x11, 0x74, 0x00, 0xcb, 0x44, 0x1a, 0xea,
-	0x5e, 0x60, 0x99, 0x07, 0x4b, 0x4f, 0x2e, 0x17, 0x57, 0x16, 0x35, 0x09, 0x21, 0xc0, 0x1b, 0x56,
-	0x48, 0xdb, 0x21, 0xe6, 0x65, 0xea, 0xb8, 0xb5, 0xd5, 0xfb, 0x7f, 0x57, 0x0b, 0x3f, 0xfc, 0x53,
-	0x7d, 0xc5, 0x76, 0xfc, 0xeb, 0x9d, 0x86, 0x66, 0xd2, 0x96, 0x84, 0x2c, 0xff, 0x9c, 0x65, 0xd6,
-	0x0d, 0xdd, 0xbf, 0xd5, 0x26, 0x2c, 0x8c, 0x61, 0x46, 0x89, 0xc4, 0x11, 0xa8, 0x67, 0x60, 0x95,
-	0xe3, 0xda, 0x36, 0x7d, 0xa7, 0x4b, 0xd2, 0xb8, 0xa9, 0x57, 0xe0, 0x52, 0xb6, 0x8b, 0x24, 0x70,
-	0x06, 0x3e, 0x8d, 0xb9, 0x39, 0x06, 0xff, 0x94, 0x51, 0x14, 0x6b, 0x22, 0x93, 0x03, 0x17, 0xf9,
-	0x36, 0xbb, 0x84, 0x58, 0xc4, 0xdb, 0x21, 0x4d, 0x62, 0xf3, 0x1e, 0x86, 0x25, 0x7c, 0x0b, 0x96,
-	0xbb, 0xb8, 0xe9, 0x58, 0xd8, 0xa7, 0x5e, 0x1d, 0x5b, 0x96, 0x27, 0x6a, 0x59, 0x9b, 0x7f, 0xf8,
-	0xe3, 0xd9, 0x39, 0x59, 0x86, 0x6d, 0xcb, 0xf2, 0x08, 0x63, 0x1f, 0xfa, 0x9e, 0xe3, 0xda, 0x46,
-	0x29, 0xf2, 0x0f, 0xd6, 0x63, 0xd5, 0xde, 0x82, 0xcf, 0x67, 0xa4, 0x92, 0x70, 0xab, 0xb0, 0xb8,
-	0xcf, 0x6d, 0xb1, 0x44, 0x06, 0x14, 0x4b, 0xc1, 0x5e, 0xaa, 0x05, 0x9f, 0xe5, 0x3b, 0xbc, 0xe7,
-	0x30, 0x76, 0x99, 0x76, 0x5c, 0x9f, 0x78, 0xc7, 0x80, 0xf3, 0x4d, 0x38, 0x3f, 0x98, 0xa5, 0x57,
-	0xd1, 0x96, 0xc3, 0x58, 0xdd, 0x14, 0xeb, 0x3c, 0xc9, 0x09, 0xa3, 0xd8, 0xea, 0xb9, 0x46, 0x15,
-	0xdd, 0xb6, 0x6d, 0x2f, 0x60, 0x48, 0xf6, 0x3c, 0xd2, 0xa5, 0x3e, 0x39, 0x06, 0xa4, 0x5f, 0x01,
-	0x59, 0xd2, 0xc1, 0x5c, 0x12, 0xef, 0x0d, 0x38, 0x8b, 0x43, 0x5b, 0xbd, 0x2d, 0x8c, 0x3c, 0x5f,
-	0x71, 0x65, 0x4d, 0xcb, 0xbe, 0xee, 0x5a, 0xb4, 0x61, 0xfc, 0x60, 0xc9, 0xcd, 0x6b, 0x27, 0x82,
-	0x13, 0x6e, 0xcc, 0xe0, 0xbe, 0xa4, 0x6a, 0x35, 0x03, 0x4d, 0x74, 0x66, 0xbf, 0x06, 0x50, 0xc9,
-	0xf2, 0x90, 0x80, 0x5b, 0x10, 0x0d, 0x00, 0x0e, 0xef, 0xdd, 0xe3, 0x22, 0x9e, 0xed, 0x47, 0xcc,
-	0xd4, 0x7d, 0x39, 0x3e, 0xa2, 0xe8, 0x6b, 0xc7, 0xd3, 0xa9, 0xcf, 0xc2, 0x49, 0xd3, 0x97, 0x48,
-	0xb2, 0x6e, 0xc0, 0x72, 0x8f, 0x75, 0xac, 0x47, 0xaf, 0x8f, 0xcd, 0xf8, 0x5a, 0x8f, 0x6e, 0x09,
-	0xc7, 0x73, 0xa9, 0x8b, 0x69, 0x08, 0xa2, 0xd6, 0x7c, 0x01, 0xe0, 0x73, 0xa9, 0x66, 0x89, 0xd0,
-	0x82, 0xd3, 0x49, 0x84, 0x61, 0x53, 0x1e, 0x0b, 0x62, 0x39, 0x01, 0x91, 0xa9, 0x73, 0x10, 0x71,
-	0x10, 0x7b, 0xd8, 0xc3, 0xad, 0x08, 0xdb, 0xc7, 0xf0, 0x74, 0x62, 0x55, 0x42, 0xda, 0x82, 0x53,
-	0x6d, 0xbe, 0x22, 0x8b, 0xa5, 0x0e, 0x43, 0x22, 0x62, 0x65, 0x5a, 0x19, 0x17, 0x1d, 0x58, 0x83,
-	0x7c, 0x8a, 0x3d, 0x6b, 0x8f, 0xd2, 0x66, 0x0d, 0x37, 0xb1, 0x6b, 0x86, 0x27, 0x20, 0x10, 0x08,
-	0x25, 0xcb, 0x43, 0xa2, 0xf0, 0xe1, 0xb4, 0x47, 0x5a, 0xd8, 0x71, 0x1d, 0xd7, 0xae, 0xef, 0x77,
-	0x5c, 0x2b, 0x2c, 0xcc, 0x42, 0xaa, 0x4a, 0x70, 0x89, 0x78, 0x4d, 0x4a, 0xc4, 0x72, 0x0e, 0x89,
-	0x10, 0xfa, 0x50, 0x8e, 0x72, 0xec, 0x06, 0x29, 0x56, 0xfe, 0x98, 0x86, 0x27, 0x39, 0x30, 0x74,
-	0x0f, 0xc0, 0x52, 0x62, 0xfa, 0xa3, 0xa1, 0x1d, 0xc9, 0x14, 0xcb, 0xca, 0x85, 0x71, 0xc3, 0x44,
-	0x01, 0xd4, 0xed, 0xcf, 0x7f, 0xff, 0xef, 0xdb, 0x27, 0x36, 0xd0, 0x45, 0x7d, 0x88, 0xdc, 0x73,
-	0xe5, 0x65, 0x7a, 0x52, 0x4e, 0xf5, 0xdb, 0x7c, 0xf9, 0x0e, 0x7a, 0x08, 0xe0, 0xe9, 0x14, 0x1d,
-	0x43, 0x1b, 0x23, 0x21, 0x65, 0x0b, 0x64, 0xe5, 0xd2, 0x64, 0xc1, 0x92, 0xd5, 0x16, 0x67, 0xb5,
-	0x8e, 0xd6, 0x72, 0xb0, 0x92, 0x1a, 0x9b, 0x24, 0x87, 0x7e, 0x03, 0x70, 0xa6, 0x5f, 0xea, 0xd0,
-	0xda, 0x48, 0x50, 0x19, 0x42, 0x5c, 0xb9, 0x38, 0x41, 0xa4, 0xe4, 0xb2, 0xcb, 0xb9, 0x6c, 0xa1,
-	0xcd, 0x61, 0x5c, 0xa2, 0xc9, 0xc5, 0xf4, 0xdb, 0xc9, 0xa9, 0x77, 0x47, 0x17, 0x12, 0x8c, 0x7e,
-	0x02, 0xb0, 0x18, 0x13, 0x45, 0xb4, 0x3a, 0x12, 0xd2, 0xa0, 0x50, 0x57, 0xce, 0x8f, 0x17, 0x24,
-	0x29, 0xec, 0x70, 0x0a, 0x9b, 0xe8, 0xd2, 0xa4, 0x14, 0x02, 0x85, 0x46, 0x7f, 0x01, 0x38, 0xd3,
-	0x2f, 0x3d, 0x39, 0x5a, 0x92, 0xa1, 0xe4, 0x39, 0x5a, 0x92, 0xa5, 0xcb, 0xea, 0x55, 0xce, 0xe7,
-	0x5d, 0xf4, 0xce, 0xa4, 0x7c, 0x06, 0x44, 0x12, 0xfd, 0x02, 0xe0, 0xec, 0x80, 0xae, 0xa2, 0xf1,
-	0x31, 0x46, 0x17, 0x68, 0x7d, 0x92, 0xd0, 0x71, 0x86, 0x42, 0x8c, 0xdf, 0xa0, 0xe6, 0xa3, 0x5f,
-	0x01, 0x2c, 0x25, 0xc4, 0x28, 0xc7, 0x60, 0x4b, 0x93, 0xf1, 0x1c, 0x83, 0x2d, 0x55, 0x94, 0xd5,
-	0xf7, 0x39, 0x87, 0xb7, 0xd1, 0xee, 0x08, 0x0e, 0x96, 0x33, 0xb2, 0x47, 0xbc, 0x41, 0xf7, 0x00,
-	0x2c, 0x27, 0xd5, 0x15, 0x8d, 0x09, 0x2d, 0x6a, 0xcd, 0x1b, 0x63, 0xc7, 0x49, 0x4e, 0x9b, 0x9c,
-	0xd3, 0x1a, 0xba, 0x30, 0x76, 0x5f, 0x44, 0x53, 0xbe, 0x03, 0x70, 0x4a, 0x48, 0x29, 0xd2, 0x46,
-	0x62, 0x48, 0xa8, 0x78, 0x45, 0xcf, 0xed, 0x2f, 0xb1, 0xbe, 0xcc, 0xb1, 0xbe, 0x80, 0xd4, 0x61,
-	0x58, 0x85, 0x92, 0xa3, 0x9f, 0x01, 0x7c, 0x26, 0x5d, 0xa8, 0x73, 0xdc, 0x80, 0x2c, 0xf9, 0xcf,
-	0x71, 0x03, 0x32, 0xdf, 0x05, 0xea, 0x79, 0x8e, 0x5e, 0x43, 0xaf, 0x66, 0xa3, 0xd7, 0x3d, 0x1e,
-	0x5d, 0x6f, 0x53, 0xda, 0x14, 0x4f, 0x87, 0xda, 0x47, 0xf7, 0x0f, 0x15, 0xf0, 0xe0, 0x50, 0x01,
-	0xff, 0x1e, 0x2a, 0xe0, 0x9b, 0x23, 0xa5, 0xf0, 0xe0, 0x48, 0x29, 0xfc, 0x79, 0xa4, 0x14, 0x3e,
-	0xd9, 0x88, 0xbd, 0x15, 0x62, 0x3b, 0x7e, 0xe0, 0x92, 0xf8, 0x27, 0x7f, 0x38, 0x74, 0x57, 0xf4,
-	0x83, 0x30, 0x13, 0x7f, 0x44, 0x34, 0xa6, 0xf8, 0x8f, 0xe5, 0xd5, 0x47, 0x01, 0x00, 0x00, 0xff,
-	0xff, 0xfb, 0xcc, 0x1f, 0x24, 0x0a, 0x10, 0x00, 0x00,
+	// 1164 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x58, 0xcd, 0x6f, 0xdc, 0x44,
+	0x14, 0xdf, 0x81, 0xb6, 0xa2, 0xb3, 0xc9, 0x36, 0x99, 0x46, 0x90, 0x98, 0xb0, 0x9b, 0x1a, 0x04,
+	0x11, 0x50, 0x9b, 0xe6, 0xa3, 0x4d, 0x93, 0x36, 0x24, 0x69, 0x1a, 0xf1, 0x21, 0x20, 0x35, 0xa2,
+	0x48, 0x5c, 0x56, 0x13, 0x7b, 0xe2, 0x5a, 0xf5, 0x7a, 0xb6, 0x1e, 0x67, 0x49, 0x55, 0x55, 0x42,
+	0x70, 0xe1, 0x80, 0x04, 0x12, 0x02, 0x09, 0x4e, 0x3d, 0x73, 0xe6, 0x0a, 0x12, 0x07, 0x50, 0x2f,
+	0x40, 0x55, 0x2e, 0x88, 0x03, 0xa0, 0x84, 0x03, 0x7f, 0x06, 0xf2, 0xcc, 0xd8, 0x6b, 0xef, 0xda,
+	0xbb, 0xde, 0x2d, 0x3d, 0xb5, 0x3b, 0xf3, 0x3e, 0x7e, 0xbf, 0xf7, 0xde, 0xf8, 0xfd, 0x14, 0xf8,
+	0x6c, 0x93, 0xf8, 0xcc, 0x61, 0x01, 0xf1, 0x4c, 0xa2, 0x53, 0x1f, 0x9b, 0x2e, 0xd1, 0x5b, 0x67,
+	0x76, 0x48, 0x80, 0xcf, 0xe8, 0x37, 0xf6, 0x88, 0x7f, 0x53, 0x6b, 0xfa, 0x34, 0xa0, 0x48, 0x49,
+	0xd8, 0x69, 0xc2, 0x4e, 0x93, 0x76, 0xca, 0x84, 0x4d, 0x6d, 0xca, 0xcd, 0xf4, 0xf0, 0x7f, 0xc2,
+	0x43, 0x99, 0xb6, 0x29, 0xb5, 0x5d, 0xa2, 0xe3, 0xa6, 0xa3, 0x63, 0xcf, 0xa3, 0x01, 0x0e, 0x1c,
+	0xea, 0x31, 0x79, 0xfb, 0x5c, 0x8f, 0xbc, 0x32, 0xbc, 0x30, 0xac, 0x9a, 0x94, 0x35, 0x28, 0xd3,
+	0x77, 0x30, 0x6b, 0x5b, 0x98, 0xd4, 0xf1, 0xe4, 0xfd, 0x94, 0xb8, 0xaf, 0x8b, 0xfc, 0xe2, 0x87,
+	0xb8, 0x52, 0x97, 0xe1, 0xe4, 0x95, 0x90, 0xc2, 0xe5, 0x7d, 0xf3, 0x1a, 0xf6, 0x6c, 0x62, 0xe0,
+	0x80, 0x18, 0xe4, 0xc6, 0x1e, 0x61, 0x01, 0x9a, 0x80, 0x47, 0x2d, 0xe2, 0xd1, 0xc6, 0x24, 0x98,
+	0x01, 0xb3, 0xc7, 0x0d, 0xf1, 0x63, 0xf9, 0xb1, 0x8f, 0xef, 0xd4, 0x4a, 0xff, 0xde, 0xa9, 0x95,
+	0xd4, 0xd7, 0xe0, 0x54, 0x86, 0x2f, 0x6b, 0x52, 0x8f, 0x11, 0xf4, 0x34, 0x1c, 0x25, 0xf2, 0xbc,
+	0xee, 0xe3, 0x80, 0xc8, 0x20, 0x23, 0x24, 0x61, 0x9c, 0x88, 0x55, 0x85, 0xd3, 0x3c, 0xd6, 0xba,
+	0xeb, 0x26, 0xc3, 0x31, 0x89, 0x45, 0xfd, 0x0a, 0xc0, 0xa7, 0x72, 0x0c, 0x64, 0xc2, 0x7d, 0x58,
+	0x49, 0x25, 0x64, 0x93, 0x60, 0xe6, 0xd1, 0xd9, 0xf2, 0xdc, 0xb4, 0x26, 0x09, 0x87, 0xd5, 0x89,
+	0xfa, 0xa1, 0x6d, 0x12, 0xf3, 0x12, 0x75, 0xbc, 0x8d, 0xf9, 0xbb, 0x7f, 0xd6, 0x4a, 0xdf, 0xfc,
+	0x55, 0x7b, 0xc1, 0x76, 0x82, 0x6b, 0x7b, 0x3b, 0x9a, 0x49, 0x1b, 0xb2, 0x40, 0xf2, 0x9f, 0xd3,
+	0xcc, 0xba, 0xae, 0x07, 0x37, 0x9b, 0x84, 0x45, 0x3e, 0xcc, 0x18, 0x4d, 0x92, 0x60, 0xea, 0x29,
+	0x58, 0x13, 0xd0, 0xcc, 0xc0, 0x69, 0x91, 0x4c, 0xf8, 0x97, 0xe1, 0x4c, 0xbe, 0x89, 0x24, 0x70,
+	0x0a, 0x8e, 0x60, 0x7e, 0x9d, 0x80, 0x7f, 0xdc, 0x28, 0x8b, 0x33, 0x91, 0xc9, 0x91, 0x55, 0xda,
+	0x22, 0xc4, 0x22, 0xfe, 0x26, 0x71, 0x89, 0xcd, 0x27, 0x26, 0xea, 0xd8, 0xcb, 0xb0, 0xd2, 0xc2,
+	0xae, 0x63, 0xe1, 0x80, 0xfa, 0x75, 0x6c, 0x59, 0xbe, 0xa8, 0xfa, 0xc6, 0xe4, 0xfd, 0x6f, 0x4f,
+	0x4f, 0xc8, 0x32, 0xac, 0x5b, 0x96, 0x4f, 0x18, 0x7b, 0x3b, 0xf0, 0x1d, 0xcf, 0x36, 0x46, 0x63,
+	0xfb, 0xf0, 0x3c, 0xd1, 0x90, 0x35, 0x59, 0xef, 0xee, 0x54, 0x12, 0x6e, 0x0d, 0x96, 0x77, 0xf9,
+	0x5d, 0x22, 0x91, 0x01, 0xc5, 0x51, 0x18, 0x4b, 0xb5, 0xe0, 0x13, 0x3c, 0xc2, 0x1b, 0x0e, 0x63,
+	0x97, 0xe8, 0x9e, 0x17, 0x10, 0xff, 0x21, 0xe0, 0xbc, 0x28, 0x07, 0x38, 0x95, 0xa5, 0x5d, 0xd1,
+	0x86, 0xc3, 0x58, 0xdd, 0x14, 0xe7, 0x3c, 0xc9, 0x11, 0xa3, 0xdc, 0x68, 0x9b, 0xc6, 0x15, 0x5d,
+	0xb7, 0x6d, 0x3f, 0x64, 0x48, 0xb6, 0x7d, 0xd2, 0xa2, 0xed, 0x37, 0xf0, 0x3f, 0x22, 0xfd, 0x24,
+	0x1e, 0xe1, 0xae, 0x5c, 0x12, 0xef, 0x75, 0x38, 0x8e, 0xa3, 0xbb, 0x7a, 0x53, 0x5c, 0xf2, 0x7c,
+	0xe5, 0xb9, 0x25, 0x2d, 0xff, 0xe3, 0xa2, 0xc5, 0x01, 0x93, 0x83, 0x25, 0x83, 0x6f, 0x1c, 0x09,
+	0x27, 0xdc, 0x18, 0xc3, 0x1d, 0x49, 0xd5, 0x5a, 0x0e, 0x9a, 0x78, 0x66, 0x3f, 0x05, 0xb0, 0x9a,
+	0x67, 0x21, 0x01, 0x37, 0x20, 0xea, 0x02, 0x1c, 0xbd, 0xbb, 0x07, 0x45, 0x3c, 0xde, 0x89, 0x98,
+	0xa9, 0xbb, 0xf2, 0x83, 0x13, 0x7b, 0x5f, 0x7d, 0x38, 0x9d, 0xfa, 0x00, 0x40, 0x25, 0x2b, 0x91,
+	0x64, 0xbd, 0x03, 0x2b, 0x6d, 0xd6, 0x89, 0x1e, 0x2d, 0x0e, 0xcc, 0xf8, 0x6a, 0x9b, 0xee, 0x28,
+	0x4e, 0xe6, 0x52, 0xa7, 0xb3, 0x10, 0xc4, 0xad, 0xf9, 0x08, 0xc0, 0x27, 0x33, 0xaf, 0x25, 0x42,
+	0x0b, 0x9e, 0x48, 0x23, 0x8c, 0x9a, 0xf2, 0x40, 0x10, 0x2b, 0x29, 0x88, 0x4c, 0x9d, 0x80, 0x88,
+	0x83, 0xd8, 0xc6, 0x3e, 0x6e, 0xc4, 0xd8, 0xde, 0x85, 0x27, 0x53, 0xa7, 0x12, 0xd2, 0x1a, 0x3c,
+	0xd6, 0xe4, 0x27, 0xb2, 0x58, 0x6a, 0x2f, 0x24, 0xc2, 0x57, 0xa6, 0x95, 0x7e, 0xf1, 0xc0, 0x1a,
+	0xe4, 0x7d, 0xec, 0x5b, 0xdb, 0x94, 0xba, 0x1b, 0xd8, 0xc5, 0x9e, 0x19, 0x4d, 0x80, 0xfa, 0x65,
+	0x34, 0xb0, 0x19, 0x16, 0x12, 0x45, 0x00, 0x4f, 0xf8, 0xa4, 0x81, 0x1d, 0xcf, 0xf1, 0xec, 0xfa,
+	0xee, 0x9e, 0x67, 0x45, 0x85, 0x99, 0xca, 0xdc, 0x12, 0x7c, 0x45, 0xbc, 0x24, 0x57, 0xc4, 0x6c,
+	0x81, 0x15, 0x21, 0xf6, 0x43, 0x25, 0xce, 0xb1, 0x15, 0xa6, 0x98, 0xfb, 0x7a, 0x1c, 0x1e, 0xe5,
+	0xc0, 0xd0, 0x4f, 0x00, 0x8e, 0x75, 0x6e, 0x30, 0xd4, 0xf3, 0xa5, 0xf4, 0xda, 0x8a, 0xca, 0xf9,
+	0x21, 0x3c, 0x45, 0x25, 0xd4, 0x8b, 0x1f, 0xfe, 0xf6, 0xcf, 0xe7, 0x8f, 0x9c, 0x43, 0x8b, 0x7a,
+	0x0f, 0x95, 0xc1, 0x37, 0x3e, 0xd3, 0xb1, 0xeb, 0xd6, 0xd3, 0xbb, 0x15, 0x7d, 0x07, 0xe0, 0x48,
+	0x32, 0x30, 0x5a, 0xe8, 0x0b, 0x25, 0x43, 0x62, 0x28, 0x8b, 0x03, 0x7a, 0x49, 0xf0, 0x6b, 0x1c,
+	0xfc, 0x32, 0x5a, 0x2a, 0x00, 0x3e, 0x05, 0x5c, 0xbf, 0xc5, 0x4f, 0x6f, 0xa3, 0xfb, 0x00, 0x9e,
+	0xcc, 0x58, 0xc6, 0x68, 0xa5, 0x7f, 0x45, 0x73, 0xb7, 0xbc, 0x72, 0x61, 0x38, 0xe7, 0x21, 0x48,
+	0x49, 0xa1, 0xd0, 0xd1, 0x94, 0x5f, 0x01, 0x1c, 0xeb, 0xdc, 0xd7, 0x05, 0xa6, 0x2b, 0x47, 0x4d,
+	0x14, 0x98, 0xae, 0x3c, 0x71, 0xa0, 0x6e, 0x71, 0x2e, 0x6b, 0x68, 0xb5, 0x17, 0x97, 0xf8, 0xf3,
+	0xcb, 0xf4, 0x5b, 0xe9, 0x4f, 0xf7, 0x6d, 0x5d, 0xe8, 0x08, 0xf4, 0x3d, 0x80, 0xe5, 0xc4, 0x66,
+	0x47, 0xf3, 0x7d, 0x21, 0x75, 0xab, 0x0d, 0x65, 0x61, 0x30, 0x27, 0x49, 0x61, 0x93, 0x53, 0x58,
+	0x45, 0x17, 0x86, 0xa5, 0x10, 0xca, 0x0c, 0xf4, 0x47, 0xf8, 0xe0, 0x3b, 0x16, 0x59, 0x91, 0x07,
+	0x9f, 0x2d, 0x47, 0x8a, 0x3c, 0xf8, 0x1c, 0x71, 0xa1, 0x5e, 0xe1, 0x7c, 0x5e, 0x47, 0xaf, 0x0e,
+	0xcb, 0xa7, 0x6b, 0xd3, 0xa3, 0x9f, 0x01, 0x1c, 0xef, 0x12, 0x07, 0x68, 0x70, 0x8c, 0xf1, 0x03,
+	0x5a, 0x1e, 0xc6, 0x55, 0xf2, 0x5b, 0xe7, 0xfc, 0x56, 0xd0, 0xf9, 0x82, 0xfc, 0xba, 0x85, 0x0b,
+	0xfa, 0x05, 0xc0, 0xd1, 0xd4, 0x46, 0x45, 0x8b, 0xc5, 0x01, 0x25, 0xb4, 0x88, 0x72, 0x76, 0x50,
+	0x37, 0xc9, 0xe1, 0x4d, 0xce, 0xe1, 0x15, 0xb4, 0xd5, 0x87, 0x83, 0xe5, 0xf4, 0xed, 0x11, 0x6f,
+	0xd0, 0x0f, 0x00, 0x56, 0xd2, 0x12, 0x01, 0x0d, 0x08, 0x2d, 0x6e, 0xcd, 0xb9, 0x81, 0xfd, 0x24,
+	0xa7, 0x55, 0xce, 0x69, 0x09, 0x9d, 0x1d, 0xb8, 0x2f, 0xa2, 0x29, 0x5f, 0x00, 0x78, 0x4c, 0xe8,
+	0x01, 0xa4, 0xf5, 0xc5, 0x90, 0x92, 0x22, 0x8a, 0x5e, 0xd8, 0x5e, 0x62, 0x7d, 0x9e, 0x63, 0x7d,
+	0x06, 0xa9, 0xbd, 0xb0, 0x0a, 0x39, 0x82, 0x7e, 0x04, 0xf0, 0xf1, 0x6c, 0xb5, 0x51, 0xe0, 0x05,
+	0xe4, 0x69, 0x98, 0x02, 0x2f, 0x20, 0x57, 0xdc, 0xa8, 0x0b, 0x1c, 0xbd, 0x86, 0x5e, 0xcc, 0x47,
+	0xaf, 0xfb, 0xdc, 0xbb, 0xde, 0xa4, 0xd4, 0x15, 0xfa, 0x67, 0xe3, 0x9d, 0xbb, 0x07, 0x55, 0x70,
+	0xef, 0xa0, 0x0a, 0xfe, 0x3e, 0xa8, 0x82, 0xcf, 0x0e, 0xab, 0xa5, 0x7b, 0x87, 0xd5, 0xd2, 0xef,
+	0x87, 0xd5, 0xd2, 0x7b, 0x2b, 0x09, 0xc1, 0x93, 0x88, 0xf8, 0x96, 0x47, 0x92, 0x3f, 0xb9, 0xfa,
+	0x69, 0xcd, 0xe9, 0xfb, 0x51, 0x26, 0xae, 0x84, 0x76, 0x8e, 0xf1, 0xbf, 0x2f, 0xcc, 0xff, 0x17,
+	0x00, 0x00, 0xff, 0xff, 0x87, 0xe2, 0x6a, 0x20, 0x3d, 0x11, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1003,9 +1087,10 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type QueryClient interface {
-	// ExchangeRates returns exchange rates of all denoms,
-	// or, if specified, returns a single denom
-	ExchangeRates(ctx context.Context, in *QueryExchangeRatesRequest, opts ...grpc.CallOption) (*QueryExchangeRatesResponse, error)
+	// ExchangeRates returns exchange rates of all denoms.
+	AllExchangeRates(ctx context.Context, in *QueryAllExchangeRatesRequest, opts ...grpc.CallOption) (*QueryAllExchangeRatesResponse, error)
+	// ExchangeRate returns exchange rates of a specified denom.
+	ExchangeRate(ctx context.Context, in *QueryExchangeRateRequest, opts ...grpc.CallOption) (*QueryExchangeRateResponse, error)
 	// ActiveExchangeRates returns all active denoms
 	ActiveExchangeRates(ctx context.Context, in *QueryActiveExchangeRatesRequest, opts ...grpc.CallOption) (*QueryActiveExchangeRatesResponse, error)
 	// FeederDelegation returns feeder delegation of a validator
@@ -1034,9 +1119,18 @@ func NewQueryClient(cc grpc1.ClientConn) QueryClient {
 	return &queryClient{cc}
 }
 
-func (c *queryClient) ExchangeRates(ctx context.Context, in *QueryExchangeRatesRequest, opts ...grpc.CallOption) (*QueryExchangeRatesResponse, error) {
-	out := new(QueryExchangeRatesResponse)
-	err := c.cc.Invoke(ctx, "/persistence.oracle.v1beta1.Query/ExchangeRates", in, out, opts...)
+func (c *queryClient) AllExchangeRates(ctx context.Context, in *QueryAllExchangeRatesRequest, opts ...grpc.CallOption) (*QueryAllExchangeRatesResponse, error) {
+	out := new(QueryAllExchangeRatesResponse)
+	err := c.cc.Invoke(ctx, "/persistence.oracle.v1beta1.Query/AllExchangeRates", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *queryClient) ExchangeRate(ctx context.Context, in *QueryExchangeRateRequest, opts ...grpc.CallOption) (*QueryExchangeRateResponse, error) {
+	out := new(QueryExchangeRateResponse)
+	err := c.cc.Invoke(ctx, "/persistence.oracle.v1beta1.Query/ExchangeRate", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1126,9 +1220,10 @@ func (c *queryClient) QueryRewardPoolBalance(ctx context.Context, in *QueryRewar
 
 // QueryServer is the server API for Query service.
 type QueryServer interface {
-	// ExchangeRates returns exchange rates of all denoms,
-	// or, if specified, returns a single denom
-	ExchangeRates(context.Context, *QueryExchangeRatesRequest) (*QueryExchangeRatesResponse, error)
+	// ExchangeRates returns exchange rates of all denoms.
+	AllExchangeRates(context.Context, *QueryAllExchangeRatesRequest) (*QueryAllExchangeRatesResponse, error)
+	// ExchangeRate returns exchange rates of a specified denom.
+	ExchangeRate(context.Context, *QueryExchangeRateRequest) (*QueryExchangeRateResponse, error)
 	// ActiveExchangeRates returns all active denoms
 	ActiveExchangeRates(context.Context, *QueryActiveExchangeRatesRequest) (*QueryActiveExchangeRatesResponse, error)
 	// FeederDelegation returns feeder delegation of a validator
@@ -1153,8 +1248,11 @@ type QueryServer interface {
 type UnimplementedQueryServer struct {
 }
 
-func (*UnimplementedQueryServer) ExchangeRates(ctx context.Context, req *QueryExchangeRatesRequest) (*QueryExchangeRatesResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method ExchangeRates not implemented")
+func (*UnimplementedQueryServer) AllExchangeRates(ctx context.Context, req *QueryAllExchangeRatesRequest) (*QueryAllExchangeRatesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AllExchangeRates not implemented")
+}
+func (*UnimplementedQueryServer) ExchangeRate(ctx context.Context, req *QueryExchangeRateRequest) (*QueryExchangeRateResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ExchangeRate not implemented")
 }
 func (*UnimplementedQueryServer) ActiveExchangeRates(ctx context.Context, req *QueryActiveExchangeRatesRequest) (*QueryActiveExchangeRatesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ActiveExchangeRates not implemented")
@@ -1188,20 +1286,38 @@ func RegisterQueryServer(s grpc1.Server, srv QueryServer) {
 	s.RegisterService(&_Query_serviceDesc, srv)
 }
 
-func _Query_ExchangeRates_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(QueryExchangeRatesRequest)
+func _Query_AllExchangeRates_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryAllExchangeRatesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(QueryServer).ExchangeRates(ctx, in)
+		return srv.(QueryServer).AllExchangeRates(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/persistence.oracle.v1beta1.Query/ExchangeRates",
+		FullMethod: "/persistence.oracle.v1beta1.Query/AllExchangeRates",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(QueryServer).ExchangeRates(ctx, req.(*QueryExchangeRatesRequest))
+		return srv.(QueryServer).AllExchangeRates(ctx, req.(*QueryAllExchangeRatesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Query_ExchangeRate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryExchangeRateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).ExchangeRate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/persistence.oracle.v1beta1.Query/ExchangeRate",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).ExchangeRate(ctx, req.(*QueryExchangeRateRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1373,8 +1489,12 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*QueryServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "ExchangeRates",
-			Handler:    _Query_ExchangeRates_Handler,
+			MethodName: "AllExchangeRates",
+			Handler:    _Query_AllExchangeRates_Handler,
+		},
+		{
+			MethodName: "ExchangeRate",
+			Handler:    _Query_ExchangeRate_Handler,
 		},
 		{
 			MethodName: "ActiveExchangeRates",
@@ -1417,7 +1537,7 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 	Metadata: "persistence/oracle/v1beta1/query.proto",
 }
 
-func (m *QueryExchangeRatesRequest) Marshal() (dAtA []byte, err error) {
+func (m *QueryExchangeRateRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -1427,12 +1547,12 @@ func (m *QueryExchangeRatesRequest) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *QueryExchangeRatesRequest) MarshalTo(dAtA []byte) (int, error) {
+func (m *QueryExchangeRateRequest) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *QueryExchangeRatesRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *QueryExchangeRateRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -1447,7 +1567,7 @@ func (m *QueryExchangeRatesRequest) MarshalToSizedBuffer(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 
-func (m *QueryExchangeRatesResponse) Marshal() (dAtA []byte, err error) {
+func (m *QueryExchangeRateResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -1457,12 +1577,65 @@ func (m *QueryExchangeRatesResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *QueryExchangeRatesResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *QueryExchangeRateResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *QueryExchangeRatesResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *QueryExchangeRateResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.ExchangeRate) > 0 {
+		i -= len(m.ExchangeRate)
+		copy(dAtA[i:], m.ExchangeRate)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.ExchangeRate)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryAllExchangeRatesRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryAllExchangeRatesRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryAllExchangeRatesRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryAllExchangeRatesResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryAllExchangeRatesResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryAllExchangeRatesResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -2030,7 +2203,7 @@ func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-func (m *QueryExchangeRatesRequest) Size() (n int) {
+func (m *QueryExchangeRateRequest) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -2043,7 +2216,29 @@ func (m *QueryExchangeRatesRequest) Size() (n int) {
 	return n
 }
 
-func (m *QueryExchangeRatesResponse) Size() (n int) {
+func (m *QueryExchangeRateResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.ExchangeRate)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *QueryAllExchangeRatesRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *QueryAllExchangeRatesResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -2279,7 +2474,7 @@ func sovQuery(x uint64) (n int) {
 func sozQuery(x uint64) (n int) {
 	return sovQuery(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-func (m *QueryExchangeRatesRequest) Unmarshal(dAtA []byte) error {
+func (m *QueryExchangeRateRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2302,10 +2497,10 @@ func (m *QueryExchangeRatesRequest) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: QueryExchangeRatesRequest: wiretype end group for non-group")
+			return fmt.Errorf("proto: QueryExchangeRateRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: QueryExchangeRatesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: QueryExchangeRateRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -2361,7 +2556,7 @@ func (m *QueryExchangeRatesRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *QueryExchangeRatesResponse) Unmarshal(dAtA []byte) error {
+func (m *QueryExchangeRateResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2384,10 +2579,142 @@ func (m *QueryExchangeRatesResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: QueryExchangeRatesResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: QueryExchangeRateResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: QueryExchangeRatesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: QueryExchangeRateResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExchangeRate", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ExchangeRate = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryAllExchangeRatesRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryAllExchangeRatesRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryAllExchangeRatesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryAllExchangeRatesResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryAllExchangeRatesResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryAllExchangeRatesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:

--- a/x/oracle/types/query.pb.gw.go
+++ b/x/oracle/types/query.pb.gw.go
@@ -33,35 +33,26 @@ var _ = utilities.NewDoubleArray
 var _ = descriptor.ForMessage
 var _ = metadata.Join
 
-func request_Query_ExchangeRates_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq QueryExchangeRatesRequest
+func request_Query_AllExchangeRates_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryAllExchangeRatesRequest
 	var metadata runtime.ServerMetadata
 
-	var (
-		val string
-		ok  bool
-		err error
-		_   = err
-	)
-
-	val, ok = pathParams["denom"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "denom")
-	}
-
-	protoReq.Denom, err = runtime.String(val)
-
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "denom", err)
-	}
-
-	msg, err := client.ExchangeRates(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	msg, err := client.AllExchangeRates(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
 }
 
-func local_request_Query_ExchangeRates_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq QueryExchangeRatesRequest
+func local_request_Query_AllExchangeRates_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryAllExchangeRatesRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := server.AllExchangeRates(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_Query_ExchangeRate_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryExchangeRateRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -82,7 +73,34 @@ func local_request_Query_ExchangeRates_0(ctx context.Context, marshaler runtime.
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "denom", err)
 	}
 
-	msg, err := server.ExchangeRates(ctx, &protoReq)
+	msg, err := client.ExchangeRate(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_ExchangeRate_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryExchangeRateRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["denom"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "denom")
+	}
+
+	protoReq.Denom, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "denom", err)
+	}
+
+	msg, err := server.ExchangeRate(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -399,7 +417,7 @@ func local_request_Query_QueryRewardPoolBalance_0(ctx context.Context, marshaler
 // Note that using this registration option will cause many gRPC library features to stop working. Consider using RegisterQueryHandlerFromEndpoint instead.
 func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, server QueryServer) error {
 
-	mux.Handle("GET", pattern_Query_ExchangeRates_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle("GET", pattern_Query_AllExchangeRates_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
@@ -410,7 +428,7 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := local_request_Query_ExchangeRates_0(rctx, inboundMarshaler, server, req, pathParams)
+		resp, md, err := local_request_Query_AllExchangeRates_0(rctx, inboundMarshaler, server, req, pathParams)
 		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
 		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
@@ -418,7 +436,30 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 			return
 		}
 
-		forward_Query_ExchangeRates_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_Query_AllExchangeRates_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_ExchangeRate_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_ExchangeRate_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_ExchangeRate_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -670,7 +711,7 @@ func RegisterQueryHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc
 // "QueryClient" to call the correct interceptors.
 func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, client QueryClient) error {
 
-	mux.Handle("GET", pattern_Query_ExchangeRates_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle("GET", pattern_Query_AllExchangeRates_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
@@ -679,14 +720,34 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_Query_ExchangeRates_0(rctx, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_Query_AllExchangeRates_0(rctx, inboundMarshaler, client, req, pathParams)
 		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
 
-		forward_Query_ExchangeRates_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_Query_AllExchangeRates_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_ExchangeRate_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_ExchangeRate_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_ExchangeRate_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -874,7 +935,9 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 }
 
 var (
-	pattern_Query_ExchangeRates_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4, 1, 0, 4, 1, 5, 5}, []string{"persistence", "oracle", "v1beta1", "denoms", "exchange_rates", "denom"}, "", runtime.AssumeColonVerbOpt(false)))
+	pattern_Query_AllExchangeRates_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"persistence", "oracle", "v1beta1", "denoms", "all_exchange_rates"}, "", runtime.AssumeColonVerbOpt(false)))
+
+	pattern_Query_ExchangeRate_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4, 1, 0, 4, 1, 5, 5}, []string{"persistence", "oracle", "v1beta1", "denoms", "exchange_rate", "denom"}, "", runtime.AssumeColonVerbOpt(false)))
 
 	pattern_Query_ActiveExchangeRates_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"persistence", "oracle", "v1beta1", "denoms", "active_exchange_rates"}, "", runtime.AssumeColonVerbOpt(false)))
 
@@ -896,7 +959,9 @@ var (
 )
 
 var (
-	forward_Query_ExchangeRates_0 = runtime.ForwardResponseMessage
+	forward_Query_AllExchangeRates_0 = runtime.ForwardResponseMessage
+
+	forward_Query_ExchangeRate_0 = runtime.ForwardResponseMessage
 
 	forward_Query_ActiveExchangeRates_0 = runtime.ForwardResponseMessage
 


### PR DESCRIPTION
## 1. Overview

-  Update oracle exchange_rate response to return the exchange rate of an asset in string.

- Separate `exchange_rate` and `all_exchange_rates` queries.

## 2. Implementation details

Created two separate oracle queries `exchange_rate`, and `all_exchange_rates`. 
`exchange_rate`:  Takes the asset symbol as a request and returns its exchange in string.
`all_exchange_rates`: Doesn't take any request and returns exchange rates of all the assets stored on chain in `sdk.DecCoins`

## 3. How to test/use

`cd x/oracle/ && go test -v ./...`