### PR TITLE
test: Add more tests for oracle module

### DIFF
--- a/simapp/app.go
+++ b/simapp/app.go
@@ -100,15 +100,7 @@ import (
 	oracletypes "github.com/persistenceOne/persistence-sdk/v2/x/oracle/types"
 )
 
-const (
-	appName = "SimApp"
-
-	// BondDenom defines the native staking token denomination.
-	BondDenom = "xprt"
-
-	// DisplayDenom defines the name, symbol, and display value of the persistence token.
-	DisplayDenom = "persistence"
-)
+const appName = "SimApp"
 
 var (
 	// DefaultNodeHome default home directories for the application daemon

--- a/simapp/params/params.go
+++ b/simapp/params/params.go
@@ -4,4 +4,10 @@ package params
 const (
 	StakePerAccount           = "stake_per_account"
 	InitiallyBondedValidators = "initially_bonded_validators"
+
+	// BondDenom defines the native staking token denomination.
+	BondDenom = "xprt"
+
+	// DisplayDenom defines the name, symbol, and display value of the persistence token.
+	DisplayDenom = "persistence"
 )

--- a/x/oracle/keeper/params.go
+++ b/x/oracle/keeper/params.go
@@ -19,6 +19,19 @@ func (k Keeper) GetVoteThreshold(ctx sdk.Context) (res sdk.Dec) {
 	return
 }
 
+// SetVoteThreshold sets min combined validator power voting on a denom to accept
+// it as valid.
+// TODO: this is used in tests, we should refactor the way how this is handled.
+func (k Keeper) SetVoteThreshold(ctx sdk.Context, threshold sdk.Dec) error {
+	if err := types.ValidateVoteThreshold(threshold); err != nil {
+		return err
+	}
+
+	k.paramSpace.Set(ctx, types.KeyVoteThreshold, &threshold)
+
+	return nil
+}
+
 // GetRewardDistributionWindow returns the number of vote periods during which
 // seigniorage reward comes in and then is distributed.
 func (k Keeper) GetRewardDistributionWindow(ctx sdk.Context) (res uint64) {
@@ -53,4 +66,16 @@ func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
 // SetParams sets the total set of oracle parameters.
 func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	k.paramSpace.SetParamSet(ctx, &params)
+}
+
+// GetAcceptList returns the denom list that can be activated
+func (k Keeper) GetAcceptList(ctx sdk.Context) (res types.DenomList) {
+	k.paramSpace.Get(ctx, types.KeyAcceptList, &res)
+	return
+}
+
+// SetAcceptList updates the accepted list of assets supported by the x/oracle
+// module.
+func (k Keeper) SetAcceptList(ctx sdk.Context, acceptList types.DenomList) {
+	k.paramSpace.Set(ctx, types.KeyAcceptList, acceptList)
 }

--- a/x/oracle/keeper/tally.go
+++ b/x/oracle/keeper/tally.go
@@ -32,7 +32,7 @@ func (k Keeper) BuildClaimsMapAndTally(ctx sdk.Context, params types.Params) err
 
 	for _, v := range params.AcceptList {
 		voteTargets = append(voteTargets, v.SymbolDenom)
-		voteTargetDenoms = append(voteTargetDenoms, v.BaseDenom)
+		voteTargetDenoms = append(voteTargetDenoms, v.SymbolDenom)
 	}
 
 	// Clear all exchange rates

--- a/x/oracle/types/denom_test.go
+++ b/x/oracle/types/denom_test.go
@@ -1,0 +1,109 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/persistenceOne/persistence-sdk/v2/x/oracle/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDenomString(t *testing.T) {
+	testCases := []struct {
+		denom       types.Denom
+		expectedStr string
+	}{
+		{
+			denom:       types.DenomPersistence,
+			expectedStr: "base_denom: uxprt\nsymbol_denom: XPRT\nexponent: 6\n",
+		},
+		{
+			denom:       types.DenomAtom,
+			expectedStr: "base_denom: ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2\nsymbol_denom: ATOM\nexponent: 6\n",
+		},
+	}
+
+	for _, testCase := range testCases {
+		require.Equal(t, testCase.expectedStr, testCase.denom.String())
+	}
+}
+
+func TestDenomEqual(t *testing.T) {
+	testCases := []struct {
+		denom         types.Denom
+		denomCompared types.Denom
+		equal         bool
+	}{
+		{
+			denom:         types.DenomPersistence,
+			denomCompared: types.DenomPersistence,
+			equal:         true,
+		},
+		{
+			denom:         types.DenomPersistence,
+			denomCompared: types.DenomAtom,
+			equal:         false,
+		},
+		{
+			denom:         types.DenomAtom,
+			denomCompared: types.DenomAtom,
+			equal:         true,
+		},
+		{
+			denom:         types.DenomAtom,
+			denomCompared: types.DenomPersistence,
+			equal:         false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		require.Equal(t, testCase.equal, testCase.denom.Equal(&testCase.denomCompared))
+	}
+}
+
+func TestDenomListString(t *testing.T) {
+	testCases := []struct {
+		denomList   types.DenomList
+		expectedStr string
+	}{
+		{
+			denomList:   types.DenomList{types.DenomPersistence},
+			expectedStr: "base_denom: uxprt\nsymbol_denom: XPRT\nexponent: 6",
+		},
+		{
+			denomList:   types.DenomList{types.DenomPersistence, types.DenomAtom},
+			expectedStr: "base_denom: uxprt\nsymbol_denom: XPRT\nexponent: 6\n\nbase_denom: ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2\nsymbol_denom: ATOM\nexponent: 6",
+		},
+	}
+
+	for _, testCase := range testCases {
+		require.Equal(t, testCase.expectedStr, testCase.denomList.String())
+	}
+}
+
+func TestDenomListContains(t *testing.T) {
+	testCases := []struct {
+		denomList    types.DenomList
+		denomSymbol  string
+		symbolInList bool
+	}{
+		{
+			denomList:    types.DenomList{types.DenomPersistence},
+			denomSymbol:  types.DenomPersistence.SymbolDenom,
+			symbolInList: true,
+		},
+		{
+			denomList:    types.DenomList{types.DenomPersistence},
+			denomSymbol:  types.DenomAtom.SymbolDenom,
+			symbolInList: false,
+		},
+		{
+			denomList:    types.DenomList{types.DenomPersistence, types.DenomAtom},
+			denomSymbol:  types.DenomAtom.SymbolDenom,
+			symbolInList: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		require.Equal(t, testCase.symbolInList, testCase.denomList.Contains(testCase.denomSymbol))
+	}
+}

--- a/x/oracle/types/genesis_test.go
+++ b/x/oracle/types/genesis_test.go
@@ -1,0 +1,79 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenesisValidation(t *testing.T) {
+	// Valid state
+	genState := DefaultGenesisState()
+	require.NoError(t, ValidateGenesis(genState))
+
+	// Invalid Vote Period
+	genState.Params.VotePeriod = 0
+	require.Error(t, ValidateGenesis(genState))
+
+	// Invalid VoteThreshold
+	genState = DefaultGenesisState()
+	genState.Params.VoteThreshold = sdk.NewDecWithPrec(33, 2)
+	require.Error(t, ValidateGenesis(genState))
+
+	// Invalid Rewardband
+	genState = DefaultGenesisState()
+	genState.Params.RewardBand = sdk.NewDec(2)
+	require.Error(t, ValidateGenesis(genState))
+	genState.Params.RewardBand = sdk.NewDec(-1)
+	require.Error(t, ValidateGenesis(genState))
+
+	// Invalid RewardDistributionWindow
+	genState = DefaultGenesisState()
+	genState.Params.RewardDistributionWindow = genState.Params.VotePeriod - 1
+	require.Error(t, ValidateGenesis(genState))
+
+	// Invalid SlashFraction
+	genState = DefaultGenesisState()
+	genState.Params.SlashFraction = sdk.NewDec(2)
+	require.Error(t, ValidateGenesis(genState))
+	genState.Params.SlashFraction = sdk.NewDec(-1)
+	require.Error(t, ValidateGenesis(genState))
+
+	// Invalid SlashWindow
+	genState = DefaultGenesisState()
+	genState.Params.SlashWindow = genState.Params.VotePeriod - 1
+	require.Error(t, ValidateGenesis(genState))
+
+	// Invalid MinValidPerWindow
+	genState = DefaultGenesisState()
+	genState.Params.MinValidPerWindow = sdk.NewDec(2)
+	require.Error(t, ValidateGenesis(genState))
+	genState.Params.MinValidPerWindow = sdk.NewDec(-1)
+	require.Error(t, ValidateGenesis(genState))
+
+	// Invalid AcceptList
+	genState = DefaultGenesisState()
+	genState.Params.AcceptList = DenomList{Denom{}}
+	require.Error(t, ValidateGenesis(genState))
+}
+
+func TestGetGenesisStateFromAppState(t *testing.T) {
+	emptyGenesis := GenesisState{
+		Params:                        Params{},
+		ExchangeRates:                 []ExchangeRateTuple{},
+		FeederDelegations:             []FeederDelegation{},
+		MissCounters:                  []MissCounter{},
+		AggregateExchangeRatePrevotes: []AggregateExchangeRatePrevote{},
+		AggregateExchangeRateVotes:    []AggregateExchangeRateVote{},
+	}
+
+	bz, err := json.Marshal(emptyGenesis)
+	require.Nil(t, err)
+
+	require.NotNil(t, GetGenesisStateFromAppState(ModuleCdc, map[string]json.RawMessage{
+		ModuleName: bz,
+	}))
+	require.NotNil(t, GetGenesisStateFromAppState(ModuleCdc, map[string]json.RawMessage{}))
+}

--- a/x/oracle/types/hash_test.go
+++ b/x/oracle/types/hash_test.go
@@ -1,0 +1,38 @@
+package types
+
+import (
+	"encoding/hex"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestAggregateVoteHash(t *testing.T) {
+	addrs := []sdk.AccAddress{
+		sdk.AccAddress([]byte("addr1_______________")),
+	}
+
+	aggregateVoteHash := GetAggregateVoteHash("salt", "XPRT:100,ATOM:100", sdk.ValAddress(addrs[0]))
+	hexStr := hex.EncodeToString(aggregateVoteHash)
+	aggregateVoteHashRes, err := AggregateVoteHashFromHexString(hexStr)
+	require.NoError(t, err)
+	require.Equal(t, true, aggregateVoteHash.Equal(aggregateVoteHashRes))
+	require.Equal(t, true, AggregateVoteHash([]byte{}).Empty())
+
+	got, _ := yaml.Marshal(&aggregateVoteHash)
+	require.Equal(t, aggregateVoteHash.String()+"\n", string(got))
+
+	res := AggregateVoteHash{}
+	testMarshal(t, &aggregateVoteHash, &res, aggregateVoteHash.MarshalJSON, (&res).UnmarshalJSON)
+	testMarshal(t, &aggregateVoteHash, &res, aggregateVoteHash.Marshal, (&res).Unmarshal)
+}
+
+func testMarshal(t *testing.T, original, res interface{}, marshal func() ([]byte, error), unmarshal func([]byte) error) {
+	bz, err := marshal()
+	require.NoError(t, err)
+	err = unmarshal(bz)
+	require.NoError(t, err)
+	require.EqualValues(t, original, res)
+}

--- a/x/oracle/types/params.go
+++ b/x/oracle/types/params.go
@@ -93,7 +93,7 @@ func (p *Params) ParamSetPairs() paramstypes.ParamSetPairs {
 		paramstypes.NewParamSetPair(
 			KeyVoteThreshold,
 			&p.VoteThreshold,
-			validateVoteThreshold,
+			ValidateVoteThreshold,
 		),
 		paramstypes.NewParamSetPair(
 			KeyRewardBand,
@@ -190,11 +190,11 @@ func validateVotePeriod(i interface{}) error {
 	return nil
 }
 
-// validateVoteThreshold validates oracle exchange rates power vote threshold.
+// ValidateVoteThreshold validates oracle exchange rates power vote threshold.
 // Must be
 // * a decimal value > 0.33 and <= 1.
 // * max precision is 2 (so 0.501 is not allowed)
-func validateVoteThreshold(i interface{}) error {
+func ValidateVoteThreshold(i interface{}) error {
 	v, ok := i.(sdk.Dec)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)

--- a/x/oracle/types/params_test.go
+++ b/x/oracle/types/params_test.go
@@ -47,7 +47,7 @@ func TestValidateVoteThreshold(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		err := validateVoteThreshold(tc.threshold)
+		err := ValidateVoteThreshold(tc.threshold)
 		if tc.errMsg == "" {
 			require.NoError(t, err, "test_case", tc.name)
 		} else {
@@ -91,12 +91,12 @@ func TestValidateAcceptList(t *testing.T) {
 	require.ErrorContains(t, err, "oracle parameter AcceptList Denom must have BaseDenom")
 
 	err = validateAcceptList(DenomList{
-		{BaseDenom: denomPersistence.BaseDenom, SymbolDenom: ""},
+		{BaseDenom: DenomPersistence.BaseDenom, SymbolDenom: ""},
 	})
 	require.ErrorContains(t, err, "oracle parameter AcceptList Denom must have SymbolDenom")
 
 	err = validateAcceptList(DenomList{
-		{BaseDenom: denomPersistence.BaseDenom, SymbolDenom: denomPersistence.SymbolDenom},
+		{BaseDenom: DenomPersistence.BaseDenom, SymbolDenom: DenomPersistence.SymbolDenom},
 	})
 	require.Nil(t, err)
 }

--- a/x/oracle/types/utils_test.go
+++ b/x/oracle/types/utils_test.go
@@ -12,14 +12,26 @@ import (
 )
 
 var (
-	denomPersistence = Denom{
+	DenomPersistence = Denom{
 		BaseDenom:   PersistenceDenom,
 		SymbolDenom: PersistenceSymbol,
 		Exponent:    6,
 	}
+
+	DenomAtom = Denom{
+		BaseDenom:   AtomDenom,
+		SymbolDenom: AtomSymbol,
+		Exponent:    6,
+	}
+
+	DenomOsmosis = Denom{
+		BaseDenom:   OsmosisDenom,
+		SymbolDenom: AtomSymbol,
+		Exponent:    6,
+	}
 )
 
-// MockStakingKeeper imlements the StakingKeeper interface.
+// MockStakingKeeper implements the StakingKeeper interface.
 type MockStakingKeeper struct {
 	validators []MockValidator
 }


### PR DESCRIPTION
## 1. Overview

- Add more tests in `x/types`.

- Change `v.BaseDenom` to `v.SymbolDenom`  in `tally.go`. Since we are using `symbol` everywhere.

## 2. How to test/use
`cd x/oracle/ && go test -v ./...`