### PR TITLE
fix: v46 staking paramstore migration

### DIFF
--- a/x/lsnative/staking/keeper/migrations.go
+++ b/x/lsnative/staking/keeper/migrations.go
@@ -3,7 +3,8 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	v043 "github.com/cosmos/cosmos-sdk/x/staking/migrations/v043"
-	v046 "github.com/cosmos/cosmos-sdk/x/staking/migrations/v046"
+
+	v046 "github.com/persistenceOne/persistence-sdk/v2/x/lsnative/staking/migrations/v046"
 )
 
 // Migrator is a struct for handling in-place store migrations.

--- a/x/lsnative/staking/migrations/v046/store.go
+++ b/x/lsnative/staking/migrations/v046/store.go
@@ -5,7 +5,8 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
-	"github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/staking/types"
 )
 
 // MigrateStore performs in-place store migrations from v0.43/v0.44/v0.45 to v0.46.
@@ -21,8 +22,10 @@ func MigrateStore(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.Binar
 func migrateParamsStore(ctx sdk.Context, paramstore paramtypes.Subspace) {
 	if paramstore.HasKeyTable() {
 		paramstore.Set(ctx, types.KeyMinCommissionRate, types.DefaultMinCommissionRate)
+		paramstore.Set(ctx, types.KeyExemptionFactor, types.DefaultExemptionFactor)
 	} else {
 		paramstore.WithKeyTable(types.ParamKeyTable())
 		paramstore.Set(ctx, types.KeyMinCommissionRate, types.DefaultMinCommissionRate)
+		paramstore.Set(ctx, types.KeyExemptionFactor, types.DefaultExemptionFactor)
 	}
 }


### PR DESCRIPTION
## 1. Overview

Added migration for param `KeyExemptionFactor` in staking module