### PR TITLE
fix: TotalLiquidShares nil handling logic in slashing

### DIFF
--- a/x/lsnative/staking/keeper/slash.go
+++ b/x/lsnative/staking/keeper/slash.go
@@ -131,7 +131,12 @@ func (k Keeper) Slash(ctx sdk.Context, consAddr sdk.ConsAddress, infractionHeigh
 	validator = k.RemoveValidatorTokens(ctx, validator, tokensToBurn)
 
 	// Proportionally deduct any liquid tokens from the global total
-	validatorLiquidRatio := validator.TotalLiquidShares.Quo(validator.DelegatorShares)
+	var validatorLiquidRatio sdk.Dec
+	if validator.TotalLiquidShares.IsNil() {
+		validatorLiquidRatio = sdk.ZeroDec()
+	} else {
+		validatorLiquidRatio = validator.TotalLiquidShares.Quo(validator.DelegatorShares)
+	}
 	slashedLiquidTokens := validatorLiquidRatio.Mul(sdk.NewDecFromInt(slashAmount)).TruncateInt()
 	k.DecreaseTotalLiquidStakedTokens(ctx, slashedLiquidTokens)
 


### PR DESCRIPTION
Also, both TotalLiquidShares and TotalValidatorBondShares shouldn't be nil in state, this will be handled by a migration later:
https://github.com/persistenceOne/persistenceCore/pull/195/files

