### PR TITLE
fix: add routing for sdk messages for staking/distribution and simulate

### DIFF
--- a/x/lsnative/distribution/keeper/sdk_handler.go
+++ b/x/lsnative/distribution/keeper/sdk_handler.go
@@ -1,0 +1,94 @@
+package keeper
+
+import (
+	context "context"
+
+	sdkdistr "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/distribution/types"
+)
+
+type SdkMsgHandler interface {
+	sdkdistr.MsgServer
+}
+
+// NewSdkMsgHandlerWrapper returns SdkMsgHandler that implements MsgServer for
+// vanilla sdk distribution keeper handler, allowing us to route legacy messages to a forked keeper.
+func NewSdkMsgHandlerWrapper(handler types.MsgServer) SdkMsgHandler {
+	return sdkMsgHandlerWrapper{
+		handler: handler,
+	}
+}
+
+var _ SdkMsgHandler = sdkMsgHandlerWrapper{}
+
+type sdkMsgHandlerWrapper struct {
+	handler types.MsgServer
+}
+
+// FundCommunityPool implements SdkMsgHandler
+func (h sdkMsgHandlerWrapper) FundCommunityPool(
+	ctx context.Context,
+	sdkMsg *sdkdistr.MsgFundCommunityPool,
+) (*sdkdistr.MsgFundCommunityPoolResponse, error) {
+	msg := types.MsgFundCommunityPool(*sdkMsg)
+
+	res, err := h.handler.FundCommunityPool(ctx, &msg)
+	if err != nil {
+		return nil, err
+	}
+
+	sdkResp := (sdkdistr.MsgFundCommunityPoolResponse)(*res)
+
+	return &sdkResp, nil
+}
+
+// SetWithdrawAddress implements SdkMsgHandler
+func (h sdkMsgHandlerWrapper) SetWithdrawAddress(
+	ctx context.Context,
+	sdkMsg *sdkdistr.MsgSetWithdrawAddress,
+) (*sdkdistr.MsgSetWithdrawAddressResponse, error) {
+	msg := types.MsgSetWithdrawAddress(*sdkMsg)
+
+	res, err := h.handler.SetWithdrawAddress(ctx, &msg)
+	if err != nil {
+		return nil, err
+	}
+
+	sdkResp := (sdkdistr.MsgSetWithdrawAddressResponse)(*res)
+
+	return &sdkResp, nil
+}
+
+// WithdrawDelegatorReward implements SdkMsgHandler
+func (h sdkMsgHandlerWrapper) WithdrawDelegatorReward(
+	ctx context.Context,
+	sdkMsg *sdkdistr.MsgWithdrawDelegatorReward,
+) (*sdkdistr.MsgWithdrawDelegatorRewardResponse, error) {
+	msg := types.MsgWithdrawDelegatorReward(*sdkMsg)
+
+	res, err := h.handler.WithdrawDelegatorReward(ctx, &msg)
+	if err != nil {
+		return nil, err
+	}
+
+	sdkResp := (sdkdistr.MsgWithdrawDelegatorRewardResponse)(*res)
+
+	return &sdkResp, nil
+}
+
+// WithdrawValidatorCommission implements SdkMsgHandler
+func (h sdkMsgHandlerWrapper) WithdrawValidatorCommission(
+	ctx context.Context,
+	sdkMsg *sdkdistr.MsgWithdrawValidatorCommission,
+) (*sdkdistr.MsgWithdrawValidatorCommissionResponse, error) {
+	msg := types.MsgWithdrawValidatorCommission(*sdkMsg)
+
+	res, err := h.handler.WithdrawValidatorCommission(ctx, &msg)
+	if err != nil {
+		return nil, err
+	}
+
+	sdkResp := (sdkdistr.MsgWithdrawValidatorCommissionResponse)(*res)
+
+	return &sdkResp, nil
+}

--- a/x/lsnative/distribution/module.go
+++ b/x/lsnative/distribution/module.go
@@ -16,6 +16,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	sdkdistr "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/distribution/client/cli"
 	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/distribution/keeper"
 	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/distribution/simulation"
@@ -80,6 +81,7 @@ func (AppModuleBasic) GetQueryCmd() *cobra.Command {
 // RegisterInterfaces implements InterfaceModule
 func (b AppModuleBasic) RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	types.RegisterInterfaces(registry)
+	sdkdistr.RegisterInterfaces(registry)
 }
 
 // AppModule implements an application module for the distribution module.
@@ -133,7 +135,10 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
+	msgServerImpl := keeper.NewMsgServerImpl(am.keeper)
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
+	sdkdistr.RegisterMsgServer(cfg.MsgServer(), sdkdistr.MsgServer(keeper.NewSdkMsgHandlerWrapper(msgServerImpl)))
+
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 
 	m := keeper.NewMigrator(am.keeper)

--- a/x/lsnative/distribution/simulation/sdk_operations.go
+++ b/x/lsnative/distribution/simulation/sdk_operations.go
@@ -1,0 +1,239 @@
+package simulation
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	sdkdistr "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	"github.com/cosmos/cosmos-sdk/x/simulation"
+	simappparams "github.com/persistenceOne/persistence-sdk/v2/simapp/params"
+	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/distribution/keeper"
+	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/distribution/types"
+	stakingkeeper "github.com/persistenceOne/persistence-sdk/v2/x/lsnative/staking/keeper"
+)
+
+// SdkWeightedOperations returns all the operations from the module with their respective weights
+func SdkWeightedOperations(appParams simtypes.AppParams, cdc codec.JSONCodec, ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper, sk types.StakingKeeper) simulation.WeightedOperations {
+	var weightMsgSetWithdrawAddress int
+	appParams.GetOrGenerate(cdc, OpWeightMsgSetWithdrawAddress, &weightMsgSetWithdrawAddress, nil,
+		func(_ *rand.Rand) {
+			weightMsgSetWithdrawAddress = simappparams.DefaultWeightMsgSetWithdrawAddress
+		},
+	)
+
+	var weightMsgWithdrawDelegationReward int
+	appParams.GetOrGenerate(cdc, OpWeightMsgWithdrawDelegationReward, &weightMsgWithdrawDelegationReward, nil,
+		func(_ *rand.Rand) {
+			weightMsgWithdrawDelegationReward = simappparams.DefaultWeightMsgWithdrawDelegationReward
+		},
+	)
+
+	var weightMsgWithdrawValidatorCommission int
+	appParams.GetOrGenerate(cdc, OpWeightMsgWithdrawValidatorCommission, &weightMsgWithdrawValidatorCommission, nil,
+		func(_ *rand.Rand) {
+			weightMsgWithdrawValidatorCommission = simappparams.DefaultWeightMsgWithdrawValidatorCommission
+		},
+	)
+
+	var weightMsgFundCommunityPool int
+	appParams.GetOrGenerate(cdc, OpWeightMsgFundCommunityPool, &weightMsgFundCommunityPool, nil,
+		func(_ *rand.Rand) {
+			weightMsgFundCommunityPool = simappparams.DefaultWeightMsgFundCommunityPool
+		},
+	)
+
+	stakeKeeper := sk.(stakingkeeper.Keeper)
+
+	return simulation.WeightedOperations{
+		simulation.NewWeightedOperation(
+			weightMsgSetWithdrawAddress,
+			SimulateSdkMsgSetWithdrawAddress(ak, bk, k),
+		),
+		simulation.NewWeightedOperation(
+			weightMsgWithdrawDelegationReward,
+			SimulateSdkMsgWithdrawDelegatorReward(ak, bk, k, stakeKeeper),
+		),
+		simulation.NewWeightedOperation(
+			weightMsgWithdrawValidatorCommission,
+			SimulateSdkMsgWithdrawValidatorCommission(ak, bk, k, stakeKeeper),
+		),
+		simulation.NewWeightedOperation(
+			weightMsgFundCommunityPool,
+			SimulateSdkMsgFundCommunityPool(ak, bk, k, stakeKeeper),
+		),
+	}
+}
+
+// SimulateSdkMsgSetWithdrawAddress generates a MsgSetWithdrawAddress with random values.
+func SimulateSdkMsgSetWithdrawAddress(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
+	return func(
+		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		if !k.GetWithdrawAddrEnabled(ctx) {
+			return simtypes.NoOpMsg(sdkdistr.ModuleName, sdkdistr.TypeMsgSetWithdrawAddress, "withdrawal is not enabled"), nil, nil
+		}
+
+		simAccount, _ := simtypes.RandomAcc(r, accs)
+		simToAccount, _ := simtypes.RandomAcc(r, accs)
+
+		account := ak.GetAccount(ctx, simAccount.Address)
+		spendable := bk.SpendableCoins(ctx, account.GetAddress())
+
+		msg := sdkdistr.NewMsgSetWithdrawAddress(simAccount.Address, simToAccount.Address)
+
+		txCtx := simulation.OperationInput{
+			R:               r,
+			App:             app,
+			TxGen:           simappparams.MakeTestEncodingConfig().TxConfig,
+			Cdc:             nil,
+			Msg:             msg,
+			MsgType:         msg.Type(),
+			Context:         ctx,
+			SimAccount:      simAccount,
+			AccountKeeper:   ak,
+			Bankkeeper:      bk,
+			ModuleName:      sdkdistr.ModuleName,
+			CoinsSpentInMsg: spendable,
+		}
+
+		return simulation.GenAndDeliverTxWithRandFees(txCtx)
+	}
+}
+
+// SimulateSdkMsgWithdrawDelegatorReward generates a MsgWithdrawDelegatorReward with random values.
+func SimulateSdkMsgWithdrawDelegatorReward(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper, sk stakingkeeper.Keeper) simtypes.Operation {
+	return func(
+		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		simAccount, _ := simtypes.RandomAcc(r, accs)
+		delegations := sk.GetAllDelegatorDelegations(ctx, simAccount.Address)
+		if len(delegations) == 0 {
+			return simtypes.NoOpMsg(sdkdistr.ModuleName, sdkdistr.TypeMsgWithdrawDelegatorReward, "number of delegators equal 0"), nil, nil
+		}
+
+		delegation := delegations[r.Intn(len(delegations))]
+
+		validator := sk.Validator(ctx, delegation.GetValidatorAddr())
+		if validator == nil {
+			return simtypes.NoOpMsg(sdkdistr.ModuleName, sdkdistr.TypeMsgWithdrawDelegatorReward, "validator is nil"), nil, fmt.Errorf("validator %s not found", delegation.GetValidatorAddr())
+		}
+
+		account := ak.GetAccount(ctx, simAccount.Address)
+		spendable := bk.SpendableCoins(ctx, account.GetAddress())
+
+		msg := sdkdistr.NewMsgWithdrawDelegatorReward(simAccount.Address, validator.GetOperator())
+
+		txCtx := simulation.OperationInput{
+			R:               r,
+			App:             app,
+			TxGen:           simappparams.MakeTestEncodingConfig().TxConfig,
+			Cdc:             nil,
+			Msg:             msg,
+			MsgType:         msg.Type(),
+			Context:         ctx,
+			SimAccount:      simAccount,
+			AccountKeeper:   ak,
+			Bankkeeper:      bk,
+			ModuleName:      sdkdistr.ModuleName,
+			CoinsSpentInMsg: spendable,
+		}
+
+		return simulation.GenAndDeliverTxWithRandFees(txCtx)
+	}
+}
+
+// SimulateSdkMsgWithdrawValidatorCommission generates a MsgWithdrawValidatorCommission with random values.
+func SimulateSdkMsgWithdrawValidatorCommission(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper, sk stakingkeeper.Keeper) simtypes.Operation {
+	return func(
+		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		validator, ok := stakingkeeper.RandomValidator(r, sk, ctx)
+		if !ok {
+			return simtypes.NoOpMsg(sdkdistr.ModuleName, sdkdistr.TypeMsgWithdrawValidatorCommission, "random validator is not ok"), nil, nil
+		}
+
+		commission := k.GetValidatorAccumulatedCommission(ctx, validator.GetOperator())
+		if commission.Commission.IsZero() {
+			return simtypes.NoOpMsg(sdkdistr.ModuleName, sdkdistr.TypeMsgWithdrawValidatorCommission, "validator commission is zero"), nil, nil
+		}
+
+		simAccount, found := simtypes.FindAccount(accs, sdk.AccAddress(validator.GetOperator()))
+		if !found {
+			return simtypes.NoOpMsg(sdkdistr.ModuleName, sdkdistr.TypeMsgWithdrawValidatorCommission, "could not find account"), nil, fmt.Errorf("validator %s not found", validator.GetOperator())
+		}
+
+		account := ak.GetAccount(ctx, simAccount.Address)
+		spendable := bk.SpendableCoins(ctx, account.GetAddress())
+
+		msg := sdkdistr.NewMsgWithdrawValidatorCommission(validator.GetOperator())
+
+		txCtx := simulation.OperationInput{
+			R:               r,
+			App:             app,
+			TxGen:           simappparams.MakeTestEncodingConfig().TxConfig,
+			Cdc:             nil,
+			Msg:             msg,
+			MsgType:         msg.Type(),
+			Context:         ctx,
+			SimAccount:      simAccount,
+			AccountKeeper:   ak,
+			Bankkeeper:      bk,
+			ModuleName:      sdkdistr.ModuleName,
+			CoinsSpentInMsg: spendable,
+		}
+
+		return simulation.GenAndDeliverTxWithRandFees(txCtx)
+	}
+}
+
+// SimulateSdkMsgFundCommunityPool simulates MsgFundCommunityPool execution where
+// a random account sends a random amount of its funds to the community pool.
+func SimulateSdkMsgFundCommunityPool(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper, sk stakingkeeper.Keeper) simtypes.Operation {
+	return func(
+		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		funder, _ := simtypes.RandomAcc(r, accs)
+
+		account := ak.GetAccount(ctx, funder.Address)
+		spendable := bk.SpendableCoins(ctx, account.GetAddress())
+
+		fundAmount := simtypes.RandSubsetCoins(r, spendable)
+		if fundAmount.Empty() {
+			return simtypes.NoOpMsg(sdkdistr.ModuleName, sdkdistr.TypeMsgFundCommunityPool, "fund amount is empty"), nil, nil
+		}
+
+		var (
+			fees sdk.Coins
+			err  error
+		)
+
+		coins, hasNeg := spendable.SafeSub(fundAmount...)
+		if !hasNeg {
+			fees, err = simtypes.RandomFees(r, ctx, coins)
+			if err != nil {
+				return simtypes.NoOpMsg(sdkdistr.ModuleName, sdkdistr.TypeMsgFundCommunityPool, "unable to generate fees"), nil, err
+			}
+		}
+
+		msg := sdkdistr.NewMsgFundCommunityPool(fundAmount, funder.Address)
+
+		txCtx := simulation.OperationInput{
+			R:             r,
+			App:           app,
+			TxGen:         simappparams.MakeTestEncodingConfig().TxConfig,
+			Cdc:           nil,
+			Msg:           msg,
+			MsgType:       msg.Type(),
+			Context:       ctx,
+			SimAccount:    funder,
+			AccountKeeper: ak,
+			ModuleName:    sdkdistr.ModuleName,
+		}
+
+		return simulation.GenAndDeliverTx(txCtx, fees)
+	}
+}

--- a/x/lsnative/distribution/simulation/sdk_operations_test.go
+++ b/x/lsnative/distribution/simulation/sdk_operations_test.go
@@ -1,0 +1,210 @@
+package simulation_test
+
+import (
+	"math/rand"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/cosmos/cosmos-sdk/x/bank/testutil"
+	sdkdistr "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	simappparams "github.com/persistenceOne/persistence-sdk/v2/simapp/params"
+	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/distribution/simulation"
+	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/distribution/types"
+	distrtypes "github.com/persistenceOne/persistence-sdk/v2/x/lsnative/distribution/types"
+	stakingtypes "github.com/persistenceOne/persistence-sdk/v2/x/lsnative/staking/types"
+)
+
+// TestSdkWeightedOperations tests the weights of the operations.
+func (suite *SimTestSuite) TestSdkWeightedOperations() {
+	cdc := suite.app.AppCodec()
+	appParams := make(simtypes.AppParams)
+
+	weightesOps := simulation.SdkWeightedOperations(appParams, cdc, suite.app.AccountKeeper,
+		suite.app.BankKeeper, suite.app.DistrKeeper, suite.app.StakingKeeper,
+	)
+
+	// setup 3 accounts
+	s := rand.NewSource(1)
+	r := rand.New(s)
+	accs := suite.getTestingAccounts(r, 3)
+
+	expected := []struct {
+		weight     int
+		opMsgRoute string
+		opMsgName  string
+	}{
+		{simappparams.DefaultWeightMsgSetWithdrawAddress, sdkdistr.ModuleName, sdkdistr.TypeMsgSetWithdrawAddress},
+		{simappparams.DefaultWeightMsgWithdrawDelegationReward, sdkdistr.ModuleName, sdkdistr.TypeMsgWithdrawDelegatorReward},
+		{simappparams.DefaultWeightMsgWithdrawValidatorCommission, sdkdistr.ModuleName, sdkdistr.TypeMsgWithdrawValidatorCommission},
+		{simappparams.DefaultWeightMsgFundCommunityPool, sdkdistr.ModuleName, sdkdistr.TypeMsgFundCommunityPool},
+	}
+
+	for i, w := range weightesOps {
+		operationMsg, _, _ := w.Op()(r, suite.app.BaseApp, suite.ctx, accs, "")
+		// the following checks are very much dependent from the ordering of the output given
+		// by WeightedOperations. if the ordering in WeightedOperations changes some tests
+		// will fail
+		suite.Require().Equal(expected[i].weight, w.Weight(), "weight should be the same")
+		suite.Require().Equal(expected[i].opMsgRoute, operationMsg.Route, "route should be the same")
+		suite.Require().Equal(expected[i].opMsgName, operationMsg.Name, "operation Msg name should be the same")
+	}
+}
+
+// TestSimulateSdkMsgSetWithdrawAddress tests the normal scenario of a valid message of type TypeMsgSetWithdrawAddress.
+// Abonormal scenarios, where the message is created by an errors, are not tested here.
+func (suite *SimTestSuite) TestSimulateSdkMsgSetWithdrawAddress() {
+	// setup 3 accounts
+	s := rand.NewSource(1)
+	r := rand.New(s)
+	accounts := suite.getTestingAccounts(r, 3)
+
+	// begin a new block
+	suite.app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: suite.app.LastBlockHeight() + 1, AppHash: suite.app.LastCommitID().Hash}})
+
+	// execute operation
+	op := simulation.SimulateSdkMsgSetWithdrawAddress(suite.app.AccountKeeper, suite.app.BankKeeper, suite.app.DistrKeeper)
+	operationMsg, futureOperations, err := op(r, suite.app.BaseApp, suite.ctx, accounts, "")
+	suite.Require().NoError(err)
+
+	var msg sdkdistr.MsgSetWithdrawAddress
+	sdkdistr.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
+
+	suite.Require().True(operationMsg.OK)
+	suite.Require().Equal("cosmos1ghekyjucln7y67ntx7cf27m9dpuxxemn4c8g4r", msg.DelegatorAddress)
+	suite.Require().Equal("cosmos1p8wcgrjr4pjju90xg6u9cgq55dxwq8j7u4x9a0", msg.WithdrawAddress)
+	suite.Require().Equal(sdkdistr.TypeMsgSetWithdrawAddress, msg.Type())
+	suite.Require().Equal(sdkdistr.ModuleName, msg.Route())
+	suite.Require().Len(futureOperations, 0)
+}
+
+// TestSimulateSdkMsgWithdrawDelegatorReward tests the normal scenario of a valid message
+// of type TypeMsgWithdrawDelegatorReward.
+// Abonormal scenarios, where the message is created by an errors, are not tested here.
+func (suite *SimTestSuite) TestSimulateSdkMsgWithdrawDelegatorReward() {
+	// setup 3 accounts
+	s := rand.NewSource(4)
+	r := rand.New(s)
+	accounts := suite.getTestingAccounts(r, 3)
+
+	// setup accounts[0] as validator
+	validator0 := suite.getTestingValidator0(accounts)
+
+	// setup delegation
+	delTokens := suite.app.StakingKeeper.TokensFromConsensusPower(suite.ctx, 2)
+	validator0, issuedShares := validator0.AddTokensFromDel(delTokens)
+	delegator := accounts[1]
+	delegation := stakingtypes.NewDelegation(delegator.Address, validator0.GetOperator(), issuedShares, false)
+	suite.app.StakingKeeper.SetDelegation(suite.ctx, delegation)
+	suite.app.DistrKeeper.SetDelegatorStartingInfo(suite.ctx, validator0.GetOperator(), delegator.Address, distrtypes.NewDelegatorStartingInfo(2, sdk.OneDec(), 200))
+
+	suite.setupValidatorRewards(validator0.GetOperator())
+
+	// begin a new block
+	suite.app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: suite.app.LastBlockHeight() + 1, AppHash: suite.app.LastCommitID().Hash}})
+
+	// execute operation
+	op := simulation.SimulateSdkMsgWithdrawDelegatorReward(suite.app.AccountKeeper, suite.app.BankKeeper, suite.app.DistrKeeper, suite.app.StakingKeeper)
+	operationMsg, futureOperations, err := op(r, suite.app.BaseApp, suite.ctx, accounts, "")
+	suite.Require().NoError(err)
+
+	var msg sdkdistr.MsgWithdrawDelegatorReward
+	sdkdistr.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
+
+	suite.Require().True(operationMsg.OK)
+	suite.Require().Equal("cosmosvaloper1l4s054098kk9hmr5753c6k3m2kw65h686d3mhr", msg.ValidatorAddress)
+	suite.Require().Equal("cosmos1d6u7zhjwmsucs678d7qn95uqajd4ucl9jcjt26", msg.DelegatorAddress)
+	suite.Require().Equal(sdkdistr.TypeMsgWithdrawDelegatorReward, msg.Type())
+	suite.Require().Equal(sdkdistr.ModuleName, msg.Route())
+	suite.Require().Len(futureOperations, 0)
+}
+
+// TestSimulateSdkMsgWithdrawValidatorCommission tests the normal scenario of a valid message
+// of type TypeMsgWithdrawValidatorCommission.
+// Abonormal scenarios, where the message is created by an errors, are not tested here.
+func (suite *SimTestSuite) TestSimulateSdkMsgWithdrawValidatorCommission() {
+	suite.testSimulateSdkMsgWithdrawValidatorCommission("atoken")
+	suite.testSimulateSdkMsgWithdrawValidatorCommission("tokenxxx")
+}
+
+// all the checks in this function should not fail if we change the tokenName
+func (suite *SimTestSuite) testSimulateSdkMsgWithdrawValidatorCommission(tokenName string) {
+	// setup 3 accounts
+	s := rand.NewSource(1)
+	r := rand.New(s)
+	accounts := suite.getTestingAccounts(r, 3)
+
+	// setup accounts[0] as validator
+	validator0 := suite.getTestingValidator0(accounts)
+
+	// set module account coins
+	distrAcc := suite.app.DistrKeeper.GetDistributionAccount(suite.ctx)
+	suite.Require().NoError(testutil.FundModuleAccount(suite.app.BankKeeper, suite.ctx, distrAcc.GetName(), sdk.NewCoins(
+		sdk.NewCoin(tokenName, sdk.NewInt(10)),
+		sdk.NewCoin("stake", sdk.NewInt(5)),
+	)))
+	suite.app.AccountKeeper.SetModuleAccount(suite.ctx, distrAcc)
+
+	// set outstanding rewards
+	valCommission := sdk.NewDecCoins(
+		sdk.NewDecCoinFromDec(tokenName, sdk.NewDec(5).Quo(sdk.NewDec(2))),
+		sdk.NewDecCoinFromDec("stake", sdk.NewDec(1).Quo(sdk.NewDec(1))),
+	)
+
+	suite.app.DistrKeeper.SetValidatorOutstandingRewards(suite.ctx, validator0.GetOperator(), types.ValidatorOutstandingRewards{Rewards: valCommission})
+	suite.app.DistrKeeper.SetValidatorOutstandingRewards(suite.ctx, suite.genesisVals[0].GetOperator(), types.ValidatorOutstandingRewards{Rewards: valCommission})
+
+	// setup validator accumulated commission
+	suite.app.DistrKeeper.SetValidatorAccumulatedCommission(suite.ctx, validator0.GetOperator(), types.ValidatorAccumulatedCommission{Commission: valCommission})
+	suite.app.DistrKeeper.SetValidatorAccumulatedCommission(suite.ctx, suite.genesisVals[0].GetOperator(), types.ValidatorAccumulatedCommission{Commission: valCommission})
+
+	// begin a new block
+	suite.app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: suite.app.LastBlockHeight() + 1, AppHash: suite.app.LastCommitID().Hash}})
+
+	// execute operation
+	op := simulation.SimulateSdkMsgWithdrawValidatorCommission(suite.app.AccountKeeper, suite.app.BankKeeper, suite.app.DistrKeeper, suite.app.StakingKeeper)
+	operationMsg, futureOperations, err := op(r, suite.app.BaseApp, suite.ctx, accounts, "")
+	if !operationMsg.OK {
+		suite.Require().Equal("could not find account", operationMsg.Comment)
+	} else {
+		suite.Require().NoError(err)
+
+		var msg sdkdistr.MsgWithdrawValidatorCommission
+		sdkdistr.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
+
+		suite.Require().True(operationMsg.OK)
+		suite.Require().Equal("cosmosvaloper1tnh2q55v8wyygtt9srz5safamzdengsn9dsd7z", msg.ValidatorAddress)
+		suite.Require().Equal(sdkdistr.TypeMsgWithdrawValidatorCommission, msg.Type())
+		suite.Require().Equal(sdkdistr.ModuleName, msg.Route())
+		suite.Require().Len(futureOperations, 0)
+	}
+}
+
+// TestSimulateSdkMsgFundCommunityPool tests the normal scenario of a valid message of type TypeMsgFundCommunityPool.
+// Abonormal scenarios, where the message is created by an errors, are not tested here.
+func (suite *SimTestSuite) TestSimulateSdkMsgFundCommunityPool() {
+	// setup 3 accounts
+	s := rand.NewSource(1)
+	r := rand.New(s)
+	accounts := suite.getTestingAccounts(r, 3)
+
+	// begin a new block
+	suite.app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: suite.app.LastBlockHeight() + 1, AppHash: suite.app.LastCommitID().Hash}})
+
+	// execute operation
+	op := simulation.SimulateSdkMsgFundCommunityPool(suite.app.AccountKeeper, suite.app.BankKeeper, suite.app.DistrKeeper, suite.app.StakingKeeper)
+	operationMsg, futureOperations, err := op(r, suite.app.BaseApp, suite.ctx, accounts, "")
+	suite.Require().NoError(err)
+
+	var msg sdkdistr.MsgFundCommunityPool
+	sdkdistr.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
+
+	suite.Require().True(operationMsg.OK)
+	suite.Require().Equal("4896096stake", msg.Amount.String())
+	suite.Require().Equal("cosmos1ghekyjucln7y67ntx7cf27m9dpuxxemn4c8g4r", msg.Depositor)
+	suite.Require().Equal(sdkdistr.TypeMsgFundCommunityPool, msg.Type())
+	suite.Require().Equal(sdkdistr.ModuleName, msg.Route())
+	suite.Require().Len(futureOperations, 0)
+}

--- a/x/lsnative/slashing/keeper/sdk_handler.go
+++ b/x/lsnative/slashing/keeper/sdk_handler.go
@@ -1,0 +1,42 @@
+package keeper
+
+import (
+	context "context"
+	sdkslashing "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/slashing/types"
+)
+
+type SdkMsgHandler interface {
+	sdkslashing.MsgServer
+}
+
+// NewSdkMsgHandlerWrapper returns SdkMsgHandler that implements MsgServer for
+// vanilla sdk slashing keeper handler, allowing us to route legacy messages to a forked keeper.
+func NewSdkMsgHandlerWrapper(handler types.MsgServer) SdkMsgHandler {
+	return sdkMsgHandlerWrapper{
+		handler: handler,
+	}
+}
+
+var _ SdkMsgHandler = sdkMsgHandlerWrapper{}
+
+type sdkMsgHandlerWrapper struct {
+	handler types.MsgServer
+}
+
+// Unjail implements SdkMsgHandler
+func (h sdkMsgHandlerWrapper) Unjail(
+	ctx context.Context,
+	sdkMsg *sdkslashing.MsgUnjail,
+) (*sdkslashing.MsgUnjailResponse, error) {
+	msg := types.MsgUnjail(*sdkMsg)
+
+	res, err := h.handler.Unjail(ctx, &msg)
+	if err != nil {
+		return nil, err
+	}
+
+	sdkResp := (sdkslashing.MsgUnjailResponse)(*res)
+
+	return &sdkResp, nil
+}

--- a/x/lsnative/slashing/module.go
+++ b/x/lsnative/slashing/module.go
@@ -16,6 +16,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	sdkslashing "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/slashing/client/cli"
 	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/slashing/keeper"
 	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/slashing/simulation"
@@ -49,6 +50,7 @@ func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 // RegisterInterfaces registers the module's interface types
 func (b AppModuleBasic) RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	types.RegisterInterfaces(registry)
+	sdkslashing.RegisterInterfaces(registry)
 }
 
 // DefaultGenesis returns default genesis state as raw bytes for the slashing
@@ -130,7 +132,10 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
+	msgServerImpl := keeper.NewMsgServerImpl(am.keeper)
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
+	sdkslashing.RegisterMsgServer(cfg.MsgServer(), sdkslashing.MsgServer(keeper.NewSdkMsgHandlerWrapper(msgServerImpl)))
+
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 
 	m := keeper.NewMigrator(am.keeper)

--- a/x/lsnative/slashing/simulation/sdk_operations.go
+++ b/x/lsnative/slashing/simulation/sdk_operations.go
@@ -1,0 +1,132 @@
+package simulation
+
+import (
+	"errors"
+	"math/rand"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/cosmos/cosmos-sdk/x/simulation"
+	sdkslashing "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	"github.com/persistenceOne/persistence-sdk/v2/simapp/helpers"
+	simappparams "github.com/persistenceOne/persistence-sdk/v2/simapp/params"
+	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/slashing/keeper"
+	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/slashing/types"
+	stakingkeeper "github.com/persistenceOne/persistence-sdk/v2/x/lsnative/staking/keeper"
+)
+
+// SdkWeightedOperations returns all the operations from the module with their respective weights
+func SdkWeightedOperations(
+	appParams simtypes.AppParams, cdc codec.JSONCodec, ak types.AccountKeeper,
+	bk types.BankKeeper, k keeper.Keeper, sk types.StakingKeeper,
+) simulation.WeightedOperations {
+	var weightMsgUnjail int
+	appParams.GetOrGenerate(cdc, OpWeightMsgUnjail, &weightMsgUnjail, nil,
+		func(_ *rand.Rand) {
+			weightMsgUnjail = simappparams.DefaultWeightMsgUnjail
+		},
+	)
+
+	return simulation.WeightedOperations{
+		simulation.NewWeightedOperation(
+			weightMsgUnjail,
+			SimulateSdkMsgUnjail(ak, bk, k, sk.(stakingkeeper.Keeper)),
+		),
+	}
+}
+
+// SimulateSdkMsgUnjail generates a MsgUnjail with random values
+func SimulateSdkMsgUnjail(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper, sk stakingkeeper.Keeper) simtypes.Operation {
+	return func(
+		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
+		accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		validator, ok := stakingkeeper.RandomValidator(r, sk, ctx)
+		if !ok {
+			return simtypes.NoOpMsg(sdkslashing.ModuleName, sdkslashing.TypeMsgUnjail, "validator is not ok"), nil, nil // skip
+		}
+
+		simAccount, found := simtypes.FindAccount(accs, sdk.AccAddress(validator.GetOperator()))
+		if !found {
+			return simtypes.NoOpMsg(sdkslashing.ModuleName, sdkslashing.TypeMsgUnjail, "unable to find account"), nil, nil // skip
+		}
+
+		if !validator.IsJailed() {
+			// TODO: due to this condition this message is almost, if not always, skipped !
+			return simtypes.NoOpMsg(sdkslashing.ModuleName, sdkslashing.TypeMsgUnjail, "validator is not jailed"), nil, nil
+		}
+
+		consAddr, err := validator.GetConsAddr()
+		if err != nil {
+			return simtypes.NoOpMsg(sdkslashing.ModuleName, sdkslashing.TypeMsgUnjail, "unable to get validator consensus key"), nil, err
+		}
+		info, found := k.GetValidatorSigningInfo(ctx, consAddr)
+		if !found {
+			return simtypes.NoOpMsg(sdkslashing.ModuleName, sdkslashing.TypeMsgUnjail, "unable to find validator signing info"), nil, nil // skip
+		}
+
+		selfDel := sk.Delegation(ctx, simAccount.Address, validator.GetOperator())
+		if selfDel == nil {
+			return simtypes.NoOpMsg(sdkslashing.ModuleName, sdkslashing.TypeMsgUnjail, "self delegation is nil"), nil, nil // skip
+		}
+
+		account := ak.GetAccount(ctx, sdk.AccAddress(validator.GetOperator()))
+		spendable := bk.SpendableCoins(ctx, account.GetAddress())
+
+		fees, err := simtypes.RandomFees(r, ctx, spendable)
+		if err != nil {
+			return simtypes.NoOpMsg(sdkslashing.ModuleName, sdkslashing.TypeMsgUnjail, "unable to generate fees"), nil, err
+		}
+
+		msg := sdkslashing.NewMsgUnjail(validator.GetOperator())
+
+		txCfg := simappparams.MakeTestEncodingConfig().TxConfig
+		tx, err := helpers.GenSignedMockTx(
+			r,
+			txCfg,
+			[]sdk.Msg{msg},
+			fees,
+			helpers.DefaultGenTxGas,
+			chainID,
+			[]uint64{account.GetAccountNumber()},
+			[]uint64{account.GetSequence()},
+			simAccount.PrivKey,
+		)
+		if err != nil {
+			return simtypes.NoOpMsg(sdkslashing.ModuleName, msg.Type(), "unable to generate mock tx"), nil, err
+		}
+
+		_, res, err := app.SimDeliver(txCfg.TxEncoder(), tx)
+
+		// result should fail if:
+		// - validator cannot be unjailed due to tombstone
+		// - validator is still in jailed period
+		// - self delegation too low
+		if info.Tombstoned ||
+			ctx.BlockHeader().Time.Before(info.JailedUntil) {
+			if res != nil && err == nil {
+				if info.Tombstoned {
+					return simtypes.NewOperationMsg(msg, true, "", nil), nil, errors.New("validator should not have been unjailed if validator tombstoned")
+				}
+				if ctx.BlockHeader().Time.Before(info.JailedUntil) {
+					return simtypes.NewOperationMsg(msg, true, "", nil), nil, errors.New("validator unjailed while validator still in jail period")
+				}
+			}
+			// msg failed as expected
+			return simtypes.NewOperationMsg(msg, false, "", nil), nil, nil
+		}
+
+		if err != nil {
+			noop := simtypes.NoOpMsg(sdkslashing.ModuleName, msg.Type(), "unable to deliver tx")
+			if res != nil {
+				return noop, nil, errors.New(res.Log)
+			}
+
+			return noop, nil, err
+		}
+
+		return simtypes.NewOperationMsg(msg, true, "", nil), nil, nil
+	}
+}

--- a/x/lsnative/slashing/simulation/sdk_operations_test.go
+++ b/x/lsnative/slashing/simulation/sdk_operations_test.go
@@ -1,0 +1,101 @@
+package simulation_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	sdkslashing "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	simappparams "github.com/persistenceOne/persistence-sdk/v2/simapp/params"
+	distrtypes "github.com/persistenceOne/persistence-sdk/v2/x/lsnative/distribution/types"
+	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/slashing/simulation"
+	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/slashing/types"
+	stakingtypes "github.com/persistenceOne/persistence-sdk/v2/x/lsnative/staking/types"
+)
+
+// TestSdkWeightedOperations tests the weights of the operations.
+func TestSdkWeightedOperations(t *testing.T) {
+	s := rand.NewSource(1)
+	r := rand.New(s)
+	app, ctx, accs := createTestApp(t, false, r, 3)
+	ctx.WithChainID("test-chain")
+
+	cdc := app.AppCodec()
+	appParams := make(simtypes.AppParams)
+
+	expected := []struct {
+		weight     int
+		opMsgRoute string
+		opMsgName  string
+	}{{simappparams.DefaultWeightMsgUnjail, sdkslashing.ModuleName, sdkslashing.TypeMsgUnjail}}
+
+	weightesOps := simulation.SdkWeightedOperations(appParams, cdc, app.AccountKeeper, app.BankKeeper, app.SlashingKeeper, app.StakingKeeper)
+	for i, w := range weightesOps {
+		operationMsg, _, _ := w.Op()(r, app.BaseApp, ctx, accs, ctx.ChainID())
+		// the following checks are very much dependent from the ordering of the output given
+		// by WeightedOperations. if the ordering in WeightedOperations changes some tests
+		// will fail
+		require.Equal(t, expected[i].weight, w.Weight(), "weight should be the same")
+		require.Equal(t, expected[i].opMsgRoute, operationMsg.Route, "route should be the same")
+		require.Equal(t, expected[i].opMsgName, operationMsg.Name, "operation Msg name should be the same")
+	}
+}
+
+// TestSimulateSdkMsgUnjail tests the normal scenario of a valid message of type sdkslashing.MsgUnjail.
+// Abonormal scenarios, where the message is created by an errors, are not tested here.
+func TestSimulateSdkMsgUnjail(t *testing.T) {
+	// setup 3 accounts
+	s := rand.NewSource(5)
+	r := rand.New(s)
+	app, ctx, accounts := createTestApp(t, false, r, 3)
+	blockTime := time.Now().UTC()
+	ctx = ctx.WithBlockTime(blockTime)
+
+	// remove genesis validator account
+	accounts = accounts[1:]
+
+	// setup accounts[0] as validator0
+	validator0 := getTestingValidator0(t, app, ctx, accounts)
+
+	// setup validator0 by consensus address
+	app.StakingKeeper.SetValidatorByConsAddr(ctx, validator0)
+	val0ConsAddress, err := validator0.GetConsAddr()
+	require.NoError(t, err)
+	info := types.NewValidatorSigningInfo(val0ConsAddress, int64(4), int64(3),
+		time.Unix(2, 0), false, int64(10))
+	app.SlashingKeeper.SetValidatorSigningInfo(ctx, val0ConsAddress, info)
+
+	// put validator0 in jail
+	app.StakingKeeper.Jail(ctx, val0ConsAddress)
+
+	// setup self delegation
+	delTokens := app.StakingKeeper.TokensFromConsensusPower(ctx, 2)
+	validator0, issuedShares := validator0.AddTokensFromDel(delTokens)
+	val0AccAddress, err := sdk.ValAddressFromBech32(validator0.OperatorAddress)
+	require.NoError(t, err)
+	selfDelegation := stakingtypes.NewDelegation(val0AccAddress.Bytes(), validator0.GetOperator(), issuedShares, false)
+	app.StakingKeeper.SetDelegation(ctx, selfDelegation)
+	app.DistrKeeper.SetDelegatorStartingInfo(ctx, validator0.GetOperator(), val0AccAddress.Bytes(), distrtypes.NewDelegatorStartingInfo(2, sdk.OneDec(), 200))
+
+	// begin a new block
+	app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: app.LastBlockHeight() + 1, AppHash: app.LastCommitID().Hash, Time: blockTime}})
+
+	// execute operation
+	op := simulation.SimulateSdkMsgUnjail(app.AccountKeeper, app.BankKeeper, app.SlashingKeeper, app.StakingKeeper)
+	operationMsg, futureOperations, err := op(r, app.BaseApp, ctx, accounts, "")
+	require.NoError(t, err)
+
+	var msg sdkslashing.MsgUnjail
+	sdkslashing.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
+
+	require.True(t, operationMsg.OK)
+	require.Equal(t, sdkslashing.TypeMsgUnjail, msg.Type())
+	require.Equal(t, "cosmosvaloper17s94pzwhsn4ah25tec27w70n65h5t2scgxzkv2", msg.ValidatorAddr)
+	require.Len(t, futureOperations, 0)
+}

--- a/x/lsnative/staking/keeper/sdk_handler.go
+++ b/x/lsnative/staking/keeper/sdk_handler.go
@@ -1,0 +1,142 @@
+package keeper
+
+import (
+	context "context"
+	sdkstaking "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/staking/types"
+)
+
+type SdkMsgHandler interface {
+	sdkstaking.MsgServer
+}
+
+// NewSdkMsgHandlerWrapper returns SdkMsgHandler that implements MsgServer for
+// vanilla sdk staking keeper handler, allowing us to route legacy messages to a forked keeper.
+func NewSdkMsgHandlerWrapper(handler types.MsgServer) SdkMsgHandler {
+	return sdkMsgHandlerWrapper{
+		handler: handler,
+	}
+}
+
+var _ SdkMsgHandler = sdkMsgHandlerWrapper{}
+
+type sdkMsgHandlerWrapper struct {
+	handler types.MsgServer
+}
+
+// BeginRedelegate implements SdkMsgHandler
+func (h sdkMsgHandlerWrapper) BeginRedelegate(
+	ctx context.Context,
+	sdkMsg *sdkstaking.MsgBeginRedelegate,
+) (*sdkstaking.MsgBeginRedelegateResponse, error) {
+	msg := types.MsgBeginRedelegate(*sdkMsg)
+
+	res, err := h.handler.BeginRedelegate(ctx, &msg)
+	if err != nil {
+		return nil, err
+	}
+
+	sdkResp := (sdkstaking.MsgBeginRedelegateResponse)(*res)
+
+	return &sdkResp, nil
+}
+
+// CancelUnbondingDelegation implements SdkMsgHandler
+func (h sdkMsgHandlerWrapper) CancelUnbondingDelegation(
+	ctx context.Context,
+	sdkMsg *sdkstaking.MsgCancelUnbondingDelegation,
+) (*sdkstaking.MsgCancelUnbondingDelegationResponse, error) {
+	msg := types.MsgCancelUnbondingDelegation(*sdkMsg)
+
+	res, err := h.handler.CancelUnbondingDelegation(ctx, &msg)
+	if err != nil {
+		return nil, err
+	}
+
+	sdkResp := (sdkstaking.MsgCancelUnbondingDelegationResponse)(*res)
+
+	return &sdkResp, nil
+}
+
+// CreateValidator implements SdkMsgHandler
+func (h sdkMsgHandlerWrapper) CreateValidator(
+	ctx context.Context,
+	sdkMsg *sdkstaking.MsgCreateValidator,
+) (*sdkstaking.MsgCreateValidatorResponse, error) {
+	msg := types.MsgCreateValidator{
+		Description:      types.Description(sdkMsg.Description),
+		Commission:       types.CommissionRates(sdkMsg.Commission),
+		DelegatorAddress: sdkMsg.DelegatorAddress,
+		ValidatorAddress: sdkMsg.ValidatorAddress,
+		Pubkey:           sdkMsg.Pubkey,
+		Value:            sdkMsg.Value,
+
+		// MinSelfDelegation omitted
+	}
+
+	res, err := h.handler.CreateValidator(ctx, &msg)
+	if err != nil {
+		return nil, err
+	}
+
+	sdkResp := (sdkstaking.MsgCreateValidatorResponse)(*res)
+
+	return &sdkResp, nil
+}
+
+// Delegate implements SdkMsgHandler
+func (h sdkMsgHandlerWrapper) Delegate(
+	ctx context.Context,
+	sdkMsg *sdkstaking.MsgDelegate,
+) (*sdkstaking.MsgDelegateResponse, error) {
+	msg := types.MsgDelegate(*sdkMsg)
+
+	res, err := h.handler.Delegate(ctx, &msg)
+	if err != nil {
+		return nil, err
+	}
+
+	sdkResp := (sdkstaking.MsgDelegateResponse)(*res)
+
+	return &sdkResp, nil
+}
+
+// EditValidator implements SdkMsgHandler
+func (h sdkMsgHandlerWrapper) EditValidator(
+	ctx context.Context,
+	sdkMsg *sdkstaking.MsgEditValidator,
+) (*sdkstaking.MsgEditValidatorResponse, error) {
+	msg := types.MsgEditValidator{
+		Description:      types.Description(sdkMsg.Description),
+		ValidatorAddress: sdkMsg.ValidatorAddress,
+		CommissionRate:   sdkMsg.CommissionRate,
+
+		// MinSelfDelegation omitted
+	}
+
+	res, err := h.handler.EditValidator(ctx, &msg)
+	if err != nil {
+		return nil, err
+	}
+
+	sdkResp := (sdkstaking.MsgEditValidatorResponse)(*res)
+
+	return &sdkResp, nil
+}
+
+// Undelegate implements SdkMsgHandler
+func (h sdkMsgHandlerWrapper) Undelegate(
+	ctx context.Context,
+	sdkMsg *sdkstaking.MsgUndelegate,
+) (*sdkstaking.MsgUndelegateResponse, error) {
+	msg := types.MsgUndelegate(*sdkMsg)
+
+	res, err := h.handler.Undelegate(ctx, &msg)
+	if err != nil {
+		return nil, err
+	}
+
+	sdkResp := (sdkstaking.MsgUndelegateResponse)(*res)
+
+	return &sdkResp, nil
+}

--- a/x/lsnative/staking/simulation/sdk_operations.go
+++ b/x/lsnative/staking/simulation/sdk_operations.go
@@ -1,0 +1,569 @@
+package simulation
+
+import (
+	"fmt"
+	"math/rand"
+
+	"cosmossdk.io/math"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/cosmos/cosmos-sdk/x/simulation"
+	sdkstaking "github.com/cosmos/cosmos-sdk/x/staking/types"
+	simappparams "github.com/persistenceOne/persistence-sdk/v2/simapp/params"
+	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/staking/keeper"
+	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/staking/types"
+)
+
+// SdkWeightedOperations returns all the operations from the module with their respective weights
+func SdkWeightedOperations(
+	appParams simtypes.AppParams, cdc codec.JSONCodec, ak types.AccountKeeper,
+	bk types.BankKeeper, k keeper.Keeper,
+) simulation.WeightedOperations {
+	var (
+		weightMsgCreateValidator             int
+		weightMsgEditValidator               int
+		weightMsgDelegate                    int
+		weightMsgUndelegate                  int
+		weightMsgBeginRedelegate             int
+		weightMsgCancelUnbondingDelegation   int
+		weightMsgTokenizeShares              int
+		weightMsgRedeemTokensforShares       int
+		weightMsgTransferTokenizeShareRecord int
+	)
+
+	appParams.GetOrGenerate(cdc, OpWeightMsgCreateValidator, &weightMsgCreateValidator, nil,
+		func(_ *rand.Rand) {
+			weightMsgCreateValidator = simappparams.DefaultWeightMsgCreateValidator
+		},
+	)
+
+	appParams.GetOrGenerate(cdc, OpWeightMsgEditValidator, &weightMsgEditValidator, nil,
+		func(_ *rand.Rand) {
+			weightMsgEditValidator = simappparams.DefaultWeightMsgEditValidator
+		},
+	)
+
+	appParams.GetOrGenerate(cdc, OpWeightMsgDelegate, &weightMsgDelegate, nil,
+		func(_ *rand.Rand) {
+			weightMsgDelegate = simappparams.DefaultWeightMsgDelegate
+		},
+	)
+
+	appParams.GetOrGenerate(cdc, OpWeightMsgUndelegate, &weightMsgUndelegate, nil,
+		func(_ *rand.Rand) {
+			weightMsgUndelegate = simappparams.DefaultWeightMsgUndelegate
+		},
+	)
+
+	appParams.GetOrGenerate(cdc, OpWeightMsgBeginRedelegate, &weightMsgBeginRedelegate, nil,
+		func(_ *rand.Rand) {
+			weightMsgBeginRedelegate = simappparams.DefaultWeightMsgBeginRedelegate
+		},
+	)
+
+	appParams.GetOrGenerate(cdc, OpWeightMsgCancelUnbondingDelegation, &weightMsgCancelUnbondingDelegation, nil,
+		func(_ *rand.Rand) {
+			weightMsgCancelUnbondingDelegation = simappparams.DefaultWeightMsgCancelUnbondingDelegation
+		},
+	)
+
+	appParams.GetOrGenerate(cdc, OpWeightMsgTokenizeShares, &weightMsgTokenizeShares, nil,
+		func(_ *rand.Rand) {
+			weightMsgTokenizeShares = simappparams.DefaultWeightMsgTokenizeShares
+		},
+	)
+
+	appParams.GetOrGenerate(cdc, OpWeightMsgRedeemTokensforShares, &weightMsgRedeemTokensforShares, nil,
+		func(_ *rand.Rand) {
+			weightMsgRedeemTokensforShares = simappparams.DefaultWeightMsgRedeemTokensforShares
+		},
+	)
+
+	appParams.GetOrGenerate(cdc, OpWeightMsgTransferTokenizeShareRecord, &weightMsgTransferTokenizeShareRecord, nil,
+		func(_ *rand.Rand) {
+			weightMsgTransferTokenizeShareRecord = simappparams.DefaultWeightMsgTransferTokenizeShareRecord
+		},
+	)
+
+	return simulation.WeightedOperations{
+		simulation.NewWeightedOperation(
+			weightMsgCreateValidator,
+			SimulateSdkMsgCreateValidator(ak, bk, k),
+		),
+		simulation.NewWeightedOperation(
+			weightMsgEditValidator,
+			SimulateSdkMsgEditValidator(ak, bk, k),
+		),
+		simulation.NewWeightedOperation(
+			weightMsgDelegate,
+			SimulateSdkMsgDelegate(ak, bk, k),
+		),
+		simulation.NewWeightedOperation(
+			weightMsgUndelegate,
+			SimulateSdkMsgUndelegate(ak, bk, k),
+		),
+		simulation.NewWeightedOperation(
+			weightMsgBeginRedelegate,
+			SimulateSdkMsgBeginRedelegate(ak, bk, k),
+		),
+		simulation.NewWeightedOperation(
+			weightMsgCancelUnbondingDelegation,
+			SimulateSdkMsgCancelUnbondingDelegate(ak, bk, k),
+		),
+	}
+}
+
+// SimulateSdkMsgCreateValidator generates a MsgCreateValidator with random values
+func SimulateSdkMsgCreateValidator(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
+	return func(
+		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		simAccount, _ := simtypes.RandomAcc(r, accs)
+		address := sdk.ValAddress(simAccount.Address)
+
+		// ensure the validator doesn't exist already
+		_, found := k.GetLiquidValidator(ctx, address)
+		if found {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgCreateValidator, "validator already exists"), nil, nil
+		}
+
+		denom := k.GetParams(ctx).BondDenom
+
+		balance := bk.GetBalance(ctx, simAccount.Address, denom).Amount
+		if !balance.IsPositive() {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgCreateValidator, "balance is negative"), nil, nil
+		}
+
+		amount, err := simtypes.RandPositiveInt(r, balance)
+		if err != nil {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgCreateValidator, "unable to generate positive amount"), nil, err
+		}
+
+		selfDelegation := sdk.NewCoin(denom, amount)
+
+		account := ak.GetAccount(ctx, simAccount.Address)
+		spendable := bk.SpendableCoins(ctx, account.GetAddress())
+
+		var fees sdk.Coins
+
+		coins, hasNeg := spendable.SafeSub(selfDelegation)
+		if !hasNeg {
+			fees, err = simtypes.RandomFees(r, ctx, coins)
+			if err != nil {
+				return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgCreateValidator, "unable to generate fees"), nil, err
+			}
+		}
+
+		description := sdkstaking.NewDescription(
+			simtypes.RandStringOfLength(r, 10),
+			simtypes.RandStringOfLength(r, 10),
+			simtypes.RandStringOfLength(r, 10),
+			simtypes.RandStringOfLength(r, 10),
+			simtypes.RandStringOfLength(r, 10),
+		)
+
+		maxCommission := sdk.NewDecWithPrec(int64(simtypes.RandIntBetween(r, 0, 100)), 2)
+		commission := sdkstaking.NewCommissionRates(
+			simtypes.RandomDecAmount(r, maxCommission),
+			maxCommission,
+			simtypes.RandomDecAmount(r, maxCommission),
+		)
+
+		msg, err := sdkstaking.NewMsgCreateValidator(address, simAccount.ConsKey.PubKey(), selfDelegation, description, commission, sdk.OneInt())
+		if err != nil {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, msg.Type(), "unable to create CreateValidator message"), nil, err
+		}
+
+		txCtx := simulation.OperationInput{
+			R:             r,
+			App:           app,
+			TxGen:         simappparams.MakeTestEncodingConfig().TxConfig,
+			Cdc:           nil,
+			Msg:           msg,
+			MsgType:       msg.Type(),
+			Context:       ctx,
+			SimAccount:    simAccount,
+			AccountKeeper: ak,
+			ModuleName:    sdkstaking.ModuleName,
+		}
+
+		return simulation.GenAndDeliverTx(txCtx, fees)
+	}
+}
+
+// SimulateSdkMsgEditValidator generates a MsgEditValidator with random values
+func SimulateSdkMsgEditValidator(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
+	return func(
+		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		if len(k.GetAllValidators(ctx)) == 0 {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgEditValidator, "number of validators equal zero"), nil, nil
+		}
+
+		val, ok := keeper.RandomValidator(r, k, ctx)
+		if !ok {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgEditValidator, "unable to pick a validator"), nil, nil
+		}
+
+		address := val.GetOperator()
+
+		newCommissionRate := simtypes.RandomDecAmount(r, val.Commission.MaxRate)
+
+		if err := val.Commission.ValidateNewRate(newCommissionRate, ctx.BlockHeader().Time); err != nil {
+			// skip as the commission is invalid
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgEditValidator, "invalid commission rate"), nil, nil
+		}
+
+		simAccount, found := simtypes.FindAccount(accs, sdk.AccAddress(val.GetOperator()))
+		if !found {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgEditValidator, "unable to find account"), nil, fmt.Errorf("validator %s not found", val.GetOperator())
+		}
+
+		account := ak.GetAccount(ctx, simAccount.Address)
+		spendable := bk.SpendableCoins(ctx, account.GetAddress())
+
+		description := sdkstaking.NewDescription(
+			simtypes.RandStringOfLength(r, 10),
+			simtypes.RandStringOfLength(r, 10),
+			simtypes.RandStringOfLength(r, 10),
+			simtypes.RandStringOfLength(r, 10),
+			simtypes.RandStringOfLength(r, 10),
+		)
+
+		minSelfDelegation := math.OneInt()
+		msg := sdkstaking.NewMsgEditValidator(address, description, &newCommissionRate, &minSelfDelegation)
+
+		txCtx := simulation.OperationInput{
+			R:               r,
+			App:             app,
+			TxGen:           simappparams.MakeTestEncodingConfig().TxConfig,
+			Cdc:             nil,
+			Msg:             msg,
+			MsgType:         msg.Type(),
+			Context:         ctx,
+			SimAccount:      simAccount,
+			AccountKeeper:   ak,
+			Bankkeeper:      bk,
+			ModuleName:      sdkstaking.ModuleName,
+			CoinsSpentInMsg: spendable,
+		}
+
+		return simulation.GenAndDeliverTxWithRandFees(txCtx)
+	}
+}
+
+// SimulateSdkMsgDelegate generates a MsgDelegate with random values
+func SimulateSdkMsgDelegate(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
+	return func(
+		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		denom := k.GetParams(ctx).BondDenom
+
+		if len(k.GetAllValidators(ctx)) == 0 {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgDelegate, "number of validators equal zero"), nil, nil
+		}
+
+		simAccount, _ := simtypes.RandomAcc(r, accs)
+		val, ok := keeper.RandomValidator(r, k, ctx)
+		if !ok {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgDelegate, "unable to pick a validator"), nil, nil
+		}
+
+		if val.InvalidExRate() {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgDelegate, "validator's invalid echange rate"), nil, nil
+		}
+
+		amount := bk.GetBalance(ctx, simAccount.Address, denom).Amount
+		if !amount.IsPositive() {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgDelegate, "balance is negative"), nil, nil
+		}
+
+		amount, err := simtypes.RandPositiveInt(r, amount)
+		if err != nil {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgDelegate, "unable to generate positive amount"), nil, err
+		}
+
+		bondAmt := sdk.NewCoin(denom, amount)
+
+		account := ak.GetAccount(ctx, simAccount.Address)
+		spendable := bk.SpendableCoins(ctx, account.GetAddress())
+
+		var fees sdk.Coins
+
+		coins, hasNeg := spendable.SafeSub(bondAmt)
+		if !hasNeg {
+			fees, err = simtypes.RandomFees(r, ctx, coins)
+			if err != nil {
+				return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgDelegate, "unable to generate fees"), nil, err
+			}
+		}
+
+		msg := sdkstaking.NewMsgDelegate(simAccount.Address, val.GetOperator(), bondAmt)
+
+		txCtx := simulation.OperationInput{
+			R:             r,
+			App:           app,
+			TxGen:         simappparams.MakeTestEncodingConfig().TxConfig,
+			Cdc:           nil,
+			Msg:           msg,
+			MsgType:       msg.Type(),
+			Context:       ctx,
+			SimAccount:    simAccount,
+			AccountKeeper: ak,
+			ModuleName:    sdkstaking.ModuleName,
+		}
+
+		return simulation.GenAndDeliverTx(txCtx, fees)
+	}
+}
+
+// SimulateSdkMsgUndelegate generates a MsgUndelegate with random values
+func SimulateSdkMsgUndelegate(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
+	return func(
+		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		// get random validator
+		validator, ok := keeper.RandomValidator(r, k, ctx)
+		if !ok {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgUndelegate, "validator is not ok"), nil, nil
+		}
+
+		valAddr := validator.GetOperator()
+		delegations := k.GetValidatorDelegations(ctx, validator.GetOperator())
+		if delegations == nil {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgUndelegate, "keeper does have any delegation entries"), nil, nil
+		}
+
+		// get random delegator from validator
+		delegation := delegations[r.Intn(len(delegations))]
+		delAddr := delegation.GetDelegatorAddr()
+
+		if k.HasMaxUnbondingDelegationEntries(ctx, delAddr, valAddr) {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgUndelegate, "keeper does have a max unbonding delegation entries"), nil, nil
+		}
+
+		totalBond := validator.TokensFromShares(delegation.GetShares()).TruncateInt()
+		if !totalBond.IsPositive() {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgUndelegate, "total bond is negative"), nil, nil
+		}
+
+		unbondAmt, err := simtypes.RandPositiveInt(r, totalBond)
+		if err != nil {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgUndelegate, "invalid unbond amount"), nil, err
+		}
+
+		if unbondAmt.IsZero() {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgUndelegate, "unbond amount is zero"), nil, nil
+		}
+
+		msg := sdkstaking.NewMsgUndelegate(
+			delAddr, valAddr, sdk.NewCoin(k.BondDenom(ctx), unbondAmt),
+		)
+
+		// need to retrieve the simulation account associated with delegation to retrieve PrivKey
+		var simAccount simtypes.Account
+
+		for _, simAcc := range accs {
+			if simAcc.Address.Equals(delAddr) {
+				simAccount = simAcc
+				break
+			}
+		}
+		// if simaccount.PrivKey == nil, delegation address does not exist in accs. Return error
+		if simAccount.PrivKey == nil {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, msg.Type(), "account private key is nil"), nil, fmt.Errorf("delegation addr: %s does not exist in simulation accounts", delAddr)
+		}
+
+		account := ak.GetAccount(ctx, delAddr)
+		spendable := bk.SpendableCoins(ctx, account.GetAddress())
+
+		txCtx := simulation.OperationInput{
+			R:               r,
+			App:             app,
+			TxGen:           simappparams.MakeTestEncodingConfig().TxConfig,
+			Cdc:             nil,
+			Msg:             msg,
+			MsgType:         msg.Type(),
+			Context:         ctx,
+			SimAccount:      simAccount,
+			AccountKeeper:   ak,
+			Bankkeeper:      bk,
+			ModuleName:      sdkstaking.ModuleName,
+			CoinsSpentInMsg: spendable,
+		}
+
+		return simulation.GenAndDeliverTxWithRandFees(txCtx)
+	}
+}
+
+// SimulateSdkMsgCancelUnbondingDelegate generates a MsgCancelUnbondingDelegate with random values
+func SimulateSdkMsgCancelUnbondingDelegate(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
+	return func(
+		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		if len(k.GetAllValidators(ctx)) == 0 {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgDelegate, "number of validators equal zero"), nil, nil
+		}
+		// get random account
+		simAccount, _ := simtypes.RandomAcc(r, accs)
+		// get random validator
+		validator, ok := keeper.RandomValidator(r, k, ctx)
+		if !ok {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgCancelUnbondingDelegation, "validator is not ok"), nil, nil
+		}
+
+		if validator.IsJailed() || validator.InvalidExRate() {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgCancelUnbondingDelegation, "validator is jailed"), nil, nil
+		}
+
+		valAddr := validator.GetOperator()
+		unbondingDelegation, found := k.GetUnbondingDelegation(ctx, simAccount.Address, valAddr)
+		if !found {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgCancelUnbondingDelegation, "account does have any unbonding delegation"), nil, nil
+		}
+
+		// get random unbonding delegation entry at block height
+		unbondingDelegationEntry := unbondingDelegation.Entries[r.Intn(len(unbondingDelegation.Entries))]
+
+		if unbondingDelegationEntry.CompletionTime.Before(ctx.BlockTime()) {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgCancelUnbondingDelegation, "unbonding delegation is already processed"), nil, nil
+		}
+
+		if !unbondingDelegationEntry.Balance.IsPositive() {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgCancelUnbondingDelegation, "delegator receiving balance is negative"), nil, nil
+		}
+
+		cancelBondAmt := simtypes.RandomAmount(r, unbondingDelegationEntry.Balance)
+
+		if cancelBondAmt.IsZero() {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgCancelUnbondingDelegation, "cancelBondAmt amount is zero"), nil, nil
+		}
+
+		msg := sdkstaking.NewMsgCancelUnbondingDelegation(
+			simAccount.Address, valAddr, unbondingDelegationEntry.CreationHeight, sdk.NewCoin(k.BondDenom(ctx), cancelBondAmt),
+		)
+
+		spendable := bk.SpendableCoins(ctx, simAccount.Address)
+
+		txCtx := simulation.OperationInput{
+			R:               r,
+			App:             app,
+			TxGen:           simappparams.MakeTestEncodingConfig().TxConfig,
+			Cdc:             nil,
+			Msg:             msg,
+			MsgType:         msg.Type(),
+			Context:         ctx,
+			SimAccount:      simAccount,
+			AccountKeeper:   ak,
+			Bankkeeper:      bk,
+			ModuleName:      sdkstaking.ModuleName,
+			CoinsSpentInMsg: spendable,
+		}
+
+		return simulation.GenAndDeliverTxWithRandFees(txCtx)
+	}
+}
+
+// SimulateSdkMsgBeginRedelegate generates a MsgBeginRedelegate with random values
+func SimulateSdkMsgBeginRedelegate(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
+	return func(
+		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		// get random source validator
+		srcVal, ok := keeper.RandomValidator(r, k, ctx)
+		if !ok {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgBeginRedelegate, "unable to pick validator"), nil, nil
+		}
+
+		srcAddr := srcVal.GetOperator()
+		delegations := k.GetValidatorDelegations(ctx, srcAddr)
+		if delegations == nil {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgBeginRedelegate, "keeper does have any delegation entries"), nil, nil
+		}
+
+		// get random delegator from src validator
+		delegation := delegations[r.Intn(len(delegations))]
+		delAddr := delegation.GetDelegatorAddr()
+
+		if k.HasReceivingRedelegation(ctx, delAddr, srcAddr) {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgBeginRedelegate, "receveing redelegation is not allowed"), nil, nil // skip
+		}
+
+		// get random destination validator
+		destVal, ok := keeper.RandomValidator(r, k, ctx)
+		if !ok {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgBeginRedelegate, "unable to pick validator"), nil, nil
+		}
+
+		destAddr := destVal.GetOperator()
+		if srcAddr.Equals(destAddr) || destVal.InvalidExRate() || k.HasMaxRedelegationEntries(ctx, delAddr, srcAddr, destAddr) {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgBeginRedelegate, "checks failed"), nil, nil
+		}
+
+		totalBond := srcVal.TokensFromShares(delegation.GetShares()).TruncateInt()
+		if !totalBond.IsPositive() {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgBeginRedelegate, "total bond is negative"), nil, nil
+		}
+
+		redAmt, err := simtypes.RandPositiveInt(r, totalBond)
+		if err != nil {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgBeginRedelegate, "unable to generate positive amount"), nil, err
+		}
+
+		if redAmt.IsZero() {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgBeginRedelegate, "amount is zero"), nil, nil
+		}
+
+		// check if the shares truncate to zero
+		shares, err := srcVal.SharesFromTokens(redAmt)
+		if err != nil {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgBeginRedelegate, "invalid shares"), nil, err
+		}
+
+		if srcVal.TokensFromShares(shares).TruncateInt().IsZero() {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgBeginRedelegate, "shares truncate to zero"), nil, nil // skip
+		}
+
+		// need to retrieve the simulation account associated with delegation to retrieve PrivKey
+		var simAccount simtypes.Account
+
+		for _, simAcc := range accs {
+			if simAcc.Address.Equals(delAddr) {
+				simAccount = simAcc
+				break
+			}
+		}
+
+		// if simaccount.PrivKey == nil, delegation address does not exist in accs. Return error
+		if simAccount.PrivKey == nil {
+			return simtypes.NoOpMsg(sdkstaking.ModuleName, sdkstaking.TypeMsgBeginRedelegate, "account private key is nil"), nil, fmt.Errorf("delegation addr: %s does not exist in simulation accounts", delAddr)
+		}
+
+		account := ak.GetAccount(ctx, delAddr)
+		spendable := bk.SpendableCoins(ctx, account.GetAddress())
+
+		msg := sdkstaking.NewMsgBeginRedelegate(
+			delAddr, srcAddr, destAddr,
+			sdk.NewCoin(k.BondDenom(ctx), redAmt),
+		)
+
+		txCtx := simulation.OperationInput{
+			R:               r,
+			App:             app,
+			TxGen:           simappparams.MakeTestEncodingConfig().TxConfig,
+			Cdc:             nil,
+			Msg:             msg,
+			MsgType:         msg.Type(),
+			Context:         ctx,
+			SimAccount:      simAccount,
+			AccountKeeper:   ak,
+			Bankkeeper:      bk,
+			ModuleName:      sdkstaking.ModuleName,
+			CoinsSpentInMsg: spendable,
+		}
+
+		return simulation.GenAndDeliverTxWithRandFees(txCtx)
+	}
+}

--- a/x/lsnative/staking/simulation/sdk_operations_test.go
+++ b/x/lsnative/staking/simulation/sdk_operations_test.go
@@ -1,0 +1,297 @@
+package simulation_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	sdkstaking "github.com/cosmos/cosmos-sdk/x/staking/types"
+	simappparams "github.com/persistenceOne/persistence-sdk/v2/simapp/params"
+	distrtypes "github.com/persistenceOne/persistence-sdk/v2/x/lsnative/distribution/types"
+	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/staking/simulation"
+	"github.com/persistenceOne/persistence-sdk/v2/x/lsnative/staking/types"
+)
+
+// TestSdkWeightedOperations tests the weights of the operations for sdkstaking types.
+func TestSdkWeightedOperations(t *testing.T) {
+	s := rand.NewSource(1)
+	r := rand.New(s)
+	app, ctx, accs := createTestApp(t, false, r, 3)
+
+	ctx.WithChainID("test-chain")
+
+	cdc := app.AppCodec()
+	appParams := make(simtypes.AppParams)
+
+	weightesOps := simulation.SdkWeightedOperations(appParams, cdc, app.AccountKeeper,
+		app.BankKeeper, app.StakingKeeper,
+	)
+
+	expected := []struct {
+		weight     int
+		opMsgRoute string
+		opMsgName  string
+	}{
+		{simappparams.DefaultWeightMsgCreateValidator, sdkstaking.ModuleName, sdkstaking.TypeMsgCreateValidator},
+		{simappparams.DefaultWeightMsgEditValidator, sdkstaking.ModuleName, sdkstaking.TypeMsgEditValidator},
+		{simappparams.DefaultWeightMsgDelegate, sdkstaking.ModuleName, sdkstaking.TypeMsgDelegate},
+		{simappparams.DefaultWeightMsgUndelegate, sdkstaking.ModuleName, sdkstaking.TypeMsgUndelegate},
+		{simappparams.DefaultWeightMsgBeginRedelegate, sdkstaking.ModuleName, sdkstaking.TypeMsgBeginRedelegate},
+		{simappparams.DefaultWeightMsgCancelUnbondingDelegation, sdkstaking.ModuleName, sdkstaking.TypeMsgCancelUnbondingDelegation},
+	}
+
+	for i, w := range weightesOps {
+		operationMsg, _, _ := w.Op()(r, app.BaseApp, ctx, accs, ctx.ChainID())
+		// the following checks are very much dependent from the ordering of the output given
+		// by WeightedOperations. if the ordering in WeightedOperations changes some tests
+		// will fail
+		require.Equal(t, expected[i].weight, w.Weight(), "weight should be the same")
+		require.Equal(t, expected[i].opMsgRoute, operationMsg.Route, "route should be the same")
+		require.Equal(t, expected[i].opMsgName, operationMsg.Name, "operation Msg name should be the same")
+	}
+}
+
+// TestSimulateSdkMsgCreateValidator tests the normal scenario of a valid message of type TypeMsgCreateValidator.
+// Abonormal scenarios, where the message are created by an errors are not tested here.
+func TestSimulateSdkMsgCreateValidator(t *testing.T) {
+	s := rand.NewSource(1)
+	r := rand.New(s)
+	app, ctx, accounts := createTestApp(t, false, r, 3)
+
+	// begin a new block
+	app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: app.LastBlockHeight() + 1, AppHash: app.LastCommitID().Hash}})
+
+	// execute operation
+	op := simulation.SimulateSdkMsgCreateValidator(app.AccountKeeper, app.BankKeeper, app.StakingKeeper)
+	operationMsg, futureOperations, err := op(r, app.BaseApp, ctx, accounts, "")
+	require.NoError(t, err)
+
+	var msg sdkstaking.MsgCreateValidator
+	sdkstaking.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
+
+	require.True(t, operationMsg.OK)
+	require.Equal(t, "0.080000000000000000", msg.Commission.MaxChangeRate.String())
+	require.Equal(t, "0.080000000000000000", msg.Commission.MaxRate.String())
+	require.Equal(t, "0.019527679037870745", msg.Commission.Rate.String())
+	require.Equal(t, sdkstaking.TypeMsgCreateValidator, msg.Type())
+	require.Equal(t, []byte{0xa, 0x20, 0x51, 0xde, 0xbd, 0xe8, 0xfa, 0xdf, 0x4e, 0xfc, 0x33, 0xa5, 0x16, 0x94, 0xf6, 0xee, 0xd3, 0x69, 0x7a, 0x7a, 0x1c, 0x2d, 0x50, 0xb6, 0x2, 0xf7, 0x16, 0x4e, 0x66, 0x9f, 0xff, 0x38, 0x91, 0x9b}, msg.Pubkey.Value)
+	require.Equal(t, "cosmos1ghekyjucln7y67ntx7cf27m9dpuxxemn4c8g4r", msg.DelegatorAddress)
+	require.Equal(t, "cosmosvaloper1ghekyjucln7y67ntx7cf27m9dpuxxemnsvnaes", msg.ValidatorAddress)
+	require.Len(t, futureOperations, 0)
+}
+
+// TestSimulateSdkMsgCancelUnbondingDelegation tests the normal scenario of a valid message of type TypeMsgCancelUnbondingDelegation.
+// Abonormal scenarios, where the message is
+func TestSimulateSdkMsgCancelUnbondingDelegation(t *testing.T) {
+	s := rand.NewSource(1)
+	r := rand.New(s)
+	app, ctx, accounts := createTestApp(t, false, r, 3)
+
+	blockTime := time.Now().UTC()
+	ctx = ctx.WithBlockTime(blockTime)
+
+	// remove genesis validator account
+	accounts = accounts[1:]
+
+	// setup accounts[0] as validator
+	validator0 := getTestingValidator0(t, app, ctx, accounts)
+
+	// setup delegation
+	delTokens := app.StakingKeeper.TokensFromConsensusPower(ctx, 2)
+	validator0, issuedShares := validator0.AddTokensFromDel(delTokens)
+	delegator := accounts[1]
+	delegation := types.NewDelegation(delegator.Address, validator0.GetOperator(), issuedShares, false)
+	app.StakingKeeper.SetDelegation(ctx, delegation)
+	app.DistrKeeper.SetDelegatorStartingInfo(ctx, validator0.GetOperator(), delegator.Address, distrtypes.NewDelegatorStartingInfo(2, sdk.OneDec(), 200))
+
+	setupValidatorRewards(app, ctx, validator0.GetOperator())
+
+	// unbonding delegation
+	udb := types.NewUnbondingDelegation(delegator.Address, validator0.GetOperator(), app.LastBlockHeight(), blockTime.Add(2*time.Minute), delTokens)
+	app.StakingKeeper.SetUnbondingDelegation(ctx, udb)
+	setupValidatorRewards(app, ctx, validator0.GetOperator())
+
+	// begin a new block
+	app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: app.LastBlockHeight() + 1, AppHash: app.LastCommitID().Hash, Time: blockTime}})
+
+	// execute operation
+	op := simulation.SimulateSdkMsgCancelUnbondingDelegate(app.AccountKeeper, app.BankKeeper, app.StakingKeeper)
+	accounts = []simtypes.Account{accounts[1]}
+	operationMsg, futureOperations, err := op(r, app.BaseApp, ctx, accounts, "")
+	require.NoError(t, err)
+
+	var msg sdkstaking.MsgCancelUnbondingDelegation
+	sdkstaking.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
+
+	require.True(t, operationMsg.OK)
+	require.Equal(t, types.TypeMsgCancelUnbondingDelegation, msg.Type())
+	require.Equal(t, delegator.Address.String(), msg.DelegatorAddress)
+	require.Equal(t, validator0.GetOperator().String(), msg.ValidatorAddress)
+	require.Len(t, futureOperations, 0)
+}
+
+// TestSimulateSdkMsgEditValidator tests the normal scenario of a valid message of type TypeMsgEditValidator.
+// Abonormal scenarios, where the message is created by an errors are not tested here.
+func TestSimulateSdkMsgEditValidator(t *testing.T) {
+	s := rand.NewSource(1)
+	r := rand.New(s)
+	app, ctx, accounts := createTestApp(t, false, r, 3)
+	blockTime := time.Now().UTC()
+	ctx = ctx.WithBlockTime(blockTime)
+
+	// remove genesis validator account
+	accounts = accounts[1:]
+
+	// setup accounts[0] as validator
+	_ = getTestingValidator0(t, app, ctx, accounts)
+
+	// begin a new block
+	app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: app.LastBlockHeight() + 1, AppHash: app.LastCommitID().Hash, Time: blockTime}})
+
+	// execute operation
+	op := simulation.SimulateSdkMsgEditValidator(app.AccountKeeper, app.BankKeeper, app.StakingKeeper)
+	operationMsg, futureOperations, err := op(r, app.BaseApp, ctx, accounts, "")
+	require.NoError(t, err)
+
+	var msg sdkstaking.MsgEditValidator
+	sdkstaking.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
+
+	require.True(t, operationMsg.OK)
+	require.Equal(t, "0.280623462081924936", msg.CommissionRate.String())
+	require.Equal(t, "xKGLwQvuyN", msg.Description.Moniker)
+	require.Equal(t, "SlcxgdXhhu", msg.Description.Identity)
+	require.Equal(t, "WeLrQKjLxz", msg.Description.Website)
+	require.Equal(t, "rBqDOTtGTO", msg.Description.SecurityContact)
+	require.Equal(t, types.TypeMsgEditValidator, msg.Type())
+	require.Equal(t, "cosmosvaloper1p8wcgrjr4pjju90xg6u9cgq55dxwq8j7epjs3u", msg.ValidatorAddress)
+	require.Len(t, futureOperations, 0)
+}
+
+// TestSimulateSdkMsgDelegate tests the normal scenario of a valid message of type TypeMsgDelegate.
+// Abonormal scenarios, where the message is created by an errors are not tested here.
+func TestSimulateSdkMsgDelegate(t *testing.T) {
+	s := rand.NewSource(1)
+	r := rand.New(s)
+	app, ctx, accounts := createTestApp(t, false, r, 3)
+
+	blockTime := time.Now().UTC()
+	ctx = ctx.WithBlockTime(blockTime)
+
+	// execute operation
+	op := simulation.SimulateSdkMsgDelegate(app.AccountKeeper, app.BankKeeper, app.StakingKeeper)
+	operationMsg, futureOperations, err := op(r, app.BaseApp, ctx, accounts, "")
+	require.NoError(t, err)
+
+	var msg sdkstaking.MsgDelegate
+	sdkstaking.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
+
+	require.True(t, operationMsg.OK)
+	require.Equal(t, "cosmos1ghekyjucln7y67ntx7cf27m9dpuxxemn4c8g4r", msg.DelegatorAddress)
+	require.Equal(t, "98100858108421259236", msg.Amount.Amount.String())
+	require.Equal(t, "stake", msg.Amount.Denom)
+	require.Equal(t, types.TypeMsgDelegate, msg.Type())
+	require.Equal(t, "cosmosvaloper1tnh2q55v8wyygtt9srz5safamzdengsn9dsd7z", msg.ValidatorAddress)
+	require.Len(t, futureOperations, 0)
+}
+
+// TestSimulateSdkMsgUndelegate tests the normal scenario of a valid message of type TypeMsgUndelegate.
+// Abonormal scenarios, where the message is created by an errors are not tested here.
+func TestSimulateSdkMsgUndelegate(t *testing.T) {
+	s := rand.NewSource(1)
+	r := rand.New(s)
+	app, ctx, accounts := createTestApp(t, false, r, 3)
+
+	blockTime := time.Now().UTC()
+	ctx = ctx.WithBlockTime(blockTime)
+
+	// remove genesis validator account
+	accounts = accounts[1:]
+
+	// setup accounts[0] as validator
+	validator0 := getTestingValidator0(t, app, ctx, accounts)
+
+	// setup delegation
+	delTokens := app.StakingKeeper.TokensFromConsensusPower(ctx, 2)
+	validator0, issuedShares := validator0.AddTokensFromDel(delTokens)
+	delegator := accounts[1]
+	delegation := types.NewDelegation(delegator.Address, validator0.GetOperator(), issuedShares, false)
+	app.StakingKeeper.SetDelegation(ctx, delegation)
+	app.DistrKeeper.SetDelegatorStartingInfo(ctx, validator0.GetOperator(), delegator.Address, distrtypes.NewDelegatorStartingInfo(2, sdk.OneDec(), 200))
+
+	setupValidatorRewards(app, ctx, validator0.GetOperator())
+
+	// begin a new block
+	app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: app.LastBlockHeight() + 1, AppHash: app.LastCommitID().Hash, Time: blockTime}})
+
+	// execute operation
+	op := simulation.SimulateSdkMsgUndelegate(app.AccountKeeper, app.BankKeeper, app.StakingKeeper)
+	operationMsg, futureOperations, err := op(r, app.BaseApp, ctx, accounts, "")
+	require.NoError(t, err)
+
+	var msg sdkstaking.MsgUndelegate
+	sdkstaking.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
+
+	require.True(t, operationMsg.OK)
+	require.Equal(t, "cosmos1ghekyjucln7y67ntx7cf27m9dpuxxemn4c8g4r", msg.DelegatorAddress)
+	require.Equal(t, "280623462081924937", msg.Amount.Amount.String())
+	require.Equal(t, "stake", msg.Amount.Denom)
+	require.Equal(t, types.TypeMsgUndelegate, msg.Type())
+	require.Equal(t, "cosmosvaloper1p8wcgrjr4pjju90xg6u9cgq55dxwq8j7epjs3u", msg.ValidatorAddress)
+	require.Len(t, futureOperations, 0)
+}
+
+// TestSimulateSdkMsgBeginRedelegate tests the normal scenario of a valid message of type TypeMsgBeginRedelegate.
+// Abonormal scenarios, where the message is created by an errors, are not tested here.
+func TestSimulateSdkMsgBeginRedelegate(t *testing.T) {
+	s := rand.NewSource(12)
+	r := rand.New(s)
+	app, ctx, accounts := createTestApp(t, false, r, 4)
+
+	blockTime := time.Now().UTC()
+	ctx = ctx.WithBlockTime(blockTime)
+
+	// remove genesis validator account
+	accounts = accounts[1:]
+
+	// setup accounts[0] as validator0 and accounts[1] as validator1
+	validator0 := getTestingValidator0(t, app, ctx, accounts)
+	validator1 := getTestingValidator1(t, app, ctx, accounts)
+
+	delTokens := app.StakingKeeper.TokensFromConsensusPower(ctx, 2)
+	validator0, issuedShares := validator0.AddTokensFromDel(delTokens)
+
+	// setup accounts[2] as delegator
+	delegator := accounts[2]
+	delegation := types.NewDelegation(delegator.Address, validator1.GetOperator(), issuedShares, false)
+	app.StakingKeeper.SetDelegation(ctx, delegation)
+	app.DistrKeeper.SetDelegatorStartingInfo(ctx, validator1.GetOperator(), delegator.Address, distrtypes.NewDelegatorStartingInfo(2, sdk.OneDec(), 200))
+
+	setupValidatorRewards(app, ctx, validator0.GetOperator())
+	setupValidatorRewards(app, ctx, validator1.GetOperator())
+
+	// begin a new block
+	app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: app.LastBlockHeight() + 1, AppHash: app.LastCommitID().Hash, Time: blockTime}})
+
+	// execute operation
+	op := simulation.SimulateSdkMsgBeginRedelegate(app.AccountKeeper, app.BankKeeper, app.StakingKeeper)
+	operationMsg, futureOperations, err := op(r, app.BaseApp, ctx, accounts, "")
+	require.NoError(t, err)
+
+	var msg sdkstaking.MsgBeginRedelegate
+	sdkstaking.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
+
+	require.True(t, operationMsg.OK)
+	require.Equal(t, "cosmos1092v0qgulpejj8y8hs6dmlw82x9gv8f7jfc7jl", msg.DelegatorAddress)
+	require.Equal(t, "1883752832348281252", msg.Amount.Amount.String())
+	require.Equal(t, "stake", msg.Amount.Denom)
+	require.Equal(t, types.TypeMsgBeginRedelegate, msg.Type())
+	require.Equal(t, "cosmosvaloper1gnkw3uqzflagcqn6ekjwpjanlne928qhruemah", msg.ValidatorDstAddress)
+	require.Equal(t, "cosmosvaloper1kk653svg7ksj9fmu85x9ygj4jzwlyrgs89nnn2", msg.ValidatorSrcAddress)
+	require.Len(t, futureOperations, 0)
+}


### PR DESCRIPTION
## 1. Overview

When adding LSM forked version for default staking and distribution packages, the original SDK messages are not handled and their routing was impossible on the current testnet. The following messages were affected:

**From staking:**
* `cosmos.staking.v1beta1.MsgCreateValidator`
* `cosmos.staking.v1beta1.MsgEditValidator`
* `cosmos.staking.v1beta1.MsgDelegate`
* `cosmos.staking.v1beta1.MsgBeginRedelegate`
* `cosmos.staking.v1beta1.MsgUndelegate`
* `cosmos.staking.v1beta1.MsgCancelUnbondingDelegation`
* `cosmos.staking.v1beta1.MsgUnbondValidator`

**From distribution:**
* `cosmos.distribution.v1beta1.MsgSetWithdrawAddress`
* `cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward`
* `cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission`
* `cosmos.distribution.v1beta1.MsgFundCommunityPool`

## 2. Implementation details

This PR adds a thin wrapper around MsgServer that routes all "legacy" messages into the new handler, i.e. `cosmos.staking.*` gets routed as `lsnative.staking.*`. 

It also adds a parallel suite of simulation operations into integration tests to simulate interaction using clients that  send usual `cosmos.staking.*` and `cosmos.distribution.*` messages - e.g. Keplr

## 3. How to test/use

Clone the repo, then:
```
cd x/lsnative/staking
go test -v ./...

cd -; x/lsnative/distribution
go test -v ./...
```

Without fixes to routing and a wrapper, the simulation tests would fail with errors like this:

```
--- FAIL: TestSimulateSdkMsgBeginRedelegate (0.00s)
    sdk_operations_test.go:284:
        	Error Trace:	/Users/xlab/dev/persistence/persistence-sdk/x/lsnative/staking/simulation/sdk_operations_test.go:284
        	Error:      	Received unexpected error:

        	            	github.com/cosmos/cosmos-sdk/x/auth/tx.DefaultTxDecoder.func1
        	            		/Users/xlab/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.46.11/x/auth/tx/decoder.go:42
        	            	github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).runTx
        	            		/Users/xlab/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.46.11/baseapp/baseapp.go:660
        	            	github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).SimDeliver
        	            		/Users/xlab/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.46.11/baseapp/test_helpers.go:35
        	            	github.com/cosmos/cosmos-sdk/x/simulation.GenAndDeliverTx
        	            		/Users/xlab/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.46.11/x/simulation/util.go:118
        	            	github.com/cosmos/cosmos-sdk/x/simulation.GenAndDeliverTxWithRandFees
        	            		/Users/xlab/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.46.11/x/simulation/util.go:97
        	            	github.com/persistenceOne/persistence-sdk/v2/x/lsnative/staking/simulation.SimulateSdkMsgBeginRedelegate.func1
        	            		/Users/xlab/dev/persistence/persistence-sdk/x/lsnative/staking/simulation/sdk_operations.go:567
        	            	github.com/persistenceOne/persistence-sdk/v2/x/lsnative/staking/simulation_test.TestSimulateSdkMsgBeginRedelegate
        	            		/Users/xlab/dev/persistence/persistence-sdk/x/lsnative/staking/simulation/sdk_operations_test.go:283
        	            	unable to resolve type URL /cosmos.staking.v1beta1.MsgBeginRedelegate: tx parse error
        	Test:       	TestSimulateSdkMsgBeginRedelegate
```
