### PR TITLE
fix: remove merkle path escaping

### DIFF
--- a/utils/proofs.go
+++ b/utils/proofs.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"net/url"
 
 	"cosmossdk.io/errors"
 	"github.com/cometbft/cometbft/proto/tendermint/crypto"
@@ -40,7 +39,7 @@ func ValidateProofOps(ctx sdk.Context, ibcKeeper *ibcKeeper.Keeper, connectionID
 		return fmt.Errorf("unable to fetch client state")
 	}
 
-	path := commitmenttypes.NewMerklePath([]string{module, url.PathEscape(string(key))}...)
+	path := commitmenttypes.NewMerklePath([]string{module, string(key)}...)
 
 	merkleProof, err := commitmenttypes.ConvertProofs(proofOps)
 	if err != nil {


### PR DESCRIPTION
Remove path escaping after upgrading [ibc-go](https://github.com/cosmos/ibc-go) past [7.3.2](https://github.com/cosmos/ibc-go/releases/tag/v7.3.2).

This [PR](https://github.com/cosmos/ibc-go/pull/4429) removes the escaping, so we have to do it as well on our end.